### PR TITLE
Complete refactor of configuration.

### DIFF
--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/CodeCheckerNature.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/CodeCheckerNature.java
@@ -4,8 +4,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
 
+import cc.codechecker.plugin.config.CcConfiguration;
 import cc.codechecker.plugin.config.CodeCheckerContext;
-import cc.codechecker.plugin.runtime.CodecheckerServerThread;
 
 public class CodeCheckerNature implements IProjectNature {
 
@@ -14,7 +14,9 @@ public class CodeCheckerNature implements IProjectNature {
 
     @Override
     public void configure() throws CoreException {
-        CodecheckerServerThread server = CodeCheckerContext.getInstance().getServerObject(project);
+    	CcConfiguration config = new CcConfiguration(project);
+    	config.modifyProjectEnvironmentVariables();
+    	CodeCheckerContext.getInstance().setConfig(project, config);
     }
 
     @Override

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CcConfiguration.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CcConfiguration.java
@@ -1,5 +1,12 @@
 package cc.codechecker.plugin.config;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.eclipse.cdt.core.CCorePlugin;
 import org.eclipse.cdt.core.envvar.IContributedEnvironment;
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
@@ -10,305 +17,394 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IScopeContext;
 import org.osgi.service.prefs.BackingStoreException;
 
+import com.google.common.collect.Sets;
+
+import cc.codechecker.plugin.CodeCheckerNature;
+import cc.codechecker.plugin.Logger;
 import cc.codechecker.plugin.config.Config.ConfigTypes;
+import cc.codechecker.plugin.config.Config.ConfigTypesCommon;
+import cc.codechecker.plugin.config.Config.ConfigTypesProject;
 import cc.codechecker.plugin.runtime.CodeCheckEnvironmentChecker;
 import cc.codechecker.plugin.runtime.CodecheckerServerThread;
-import cc.codechecker.plugin.CodeCheckerNature;
-import cc.codechecker.plugin.config.CodeCheckerContext;
-import cc.codechecker.plugin.views.console.ConsoleFactory;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
-import cc.codechecker.plugin.Logger;
-import org.eclipse.core.runtime.IStatus;
-
+/**
+ * Stores and manages configurations related to projects and the plugin.
+ */
 public class CcConfiguration {
 
-    //Logger
-    IProject project=null;
-    IEclipsePreferences projectPreferences=null;
-    IEclipsePreferences globalPreferences = null;
+    private static Map<ConfigTypes, String> globalConfig;
+    private static IEclipsePreferences globalPreferences;
+    
+    private static final String STR_EMPTY = "";
+    private static final String TRUE = "";
+    private static final String SEP = ":";
+    
+    private static final String CODECHECKER_WORKSPACE = ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() 
+            + "/.codechecker";
 
-    private  Map<ConfigTypes,String> defaults;//default config values
-    private  Map<ConfigTypes,String> configKeys;//textual values of config variables
-
-    public void init() {        
-        globalPreferences = ConfigurationScope.INSTANCE.getNode(CodeCheckerNature.NATURE_ID);
-        defaults=new HashMap<ConfigTypes,String>();
-        defaults.put(ConfigTypes.COMPILERS,"gcc:g++:clang");
-        defaults.put(ConfigTypes.ANAL_THREADS,"4");
-        defaults.put(ConfigTypes.IS_GLOBAL,"true");
-
-        configKeys=new HashMap<ConfigTypes,String>();
-        configKeys.put(ConfigTypes.CHECKER_PATH,"global_server_url");
-        configKeys.put(ConfigTypes.PYTHON_PATH,"location_prefix");
-        configKeys.put(ConfigTypes.COMPILERS,"compilers");
-        configKeys.put(ConfigTypes.ANAL_THREADS,"analthreads");
-        configKeys.put(ConfigTypes.CHECKER_LIST,"global_checker_command");
-        configKeys.put(ConfigTypes.IS_GLOBAL,"is_global");
-        configKeys.put(ConfigTypes.CHECKER_WORKSPACE,"checker_workspace");        
+    private static final Map<ConfigTypes, String> DEFAULT_CONFIG = new HashMap<>();
+    static {
+        DEFAULT_CONFIG.put(ConfigTypesCommon.COMPILERS,"gcc:g++:clang");
+        DEFAULT_CONFIG.put(ConfigTypesCommon.ANAL_THREADS,"4");
+        DEFAULT_CONFIG.put(ConfigTypesCommon.CHECKER_PATH,STR_EMPTY);
+        DEFAULT_CONFIG.put(ConfigTypesCommon.PYTHON_PATH,"");
+        // TODO Somehow set a default checker List OR in gui
+        // set a checkbox to use the default checkers.
+        DEFAULT_CONFIG.put(ConfigTypesCommon.CHECKER_LIST,STR_EMPTY);
     }
 
-    public CcConfiguration() {
-        init();        
-    }
+    //Project related fields
+    private IProject project;
+    private boolean useGlobal = true;
+    // This config has the same keys as global.
+    private Map<ConfigTypesCommon,String> commonProjectConfig;
+    // This config has no global meaning.
+    private Map<ConfigTypesProject, String> projectOnlyConfig;
+    private IEclipsePreferences projectPreferences;
+
+    /**
+     * Creates a project related configuration.
+     * @param project The project which the configuration should be made.
+     */
     public CcConfiguration(IProject project) {
-        super();
-        init();
         this.project = project;
 
+        loadProjectConfig(project);
+        validatePersistentProjectPreferences();
+        storeLoadedPreferences();
+        checkCodeCheckerReportDir();
+    }
+
+    /**
+     * Validates preferences stored on dist for the project. At the time of the calling of this method,
+     * the global pereferences must be initialized with this classes static methods.
+     */
+    private void validatePersistentProjectPreferences() {
+        if (projectPreferences != null) {
+            try {
+                Set<String> storedProjPrefs = Sets.newHashSet(projectPreferences.keys());
+                StringBuilder log = new StringBuilder();
+                //Check the commons.
+                for (Map.Entry<ConfigTypes, String> entry : globalConfig.entrySet()) {
+                    //if the key doesn't exist in preferences, put the corresponding kv in.
+                    if (!storedProjPrefs.contains(entry.getKey().toString())){
+                        projectPreferences.put(entry.getKey().toString(), entry.getValue());
+                        log.append(entry.getKey().toString() + SEP + entry.getValue() + System.lineSeparator());
+                    }
+                }
+                for (ConfigTypesProject ctp : ConfigTypesProject.values()){
+                    if (!storedProjPrefs.contains(ctp.toString())) {
+                    	String value;
+                        switch (ctp) {
+                            case CHECKER_WORKSPACE:
+                            	value = ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() 
+                                        + "/.codechecker/" + project.getName();
+                                break;
+                            case IS_GLOBAL:
+                            	value = TRUE;
+                                break;
+                            default:
+                            	value = STR_EMPTY;
+                                break;
+                        }
+                        projectPreferences.put(ConfigTypesProject.IS_GLOBAL.toString(), value);
+                        log.append(ctp.toString()  + SEP + value + System.lineSeparator());
+                    }
+                }
+                Logger.log(IStatus.WARNING, "Missing keys in config " + project.getName() + System.lineSeparator()
+                    + log.toString());
+                projectPreferences.flush(); // flush only saves changes, so no need for a change flag.
+            } catch (BackingStoreException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Loads project level preferences from disk.
+     * @param project The project in question.
+     */
+    public void loadProjectConfig(IProject project) {
         try {
+            // If it's an "old project" open saved context
             if (project.hasNature(CodeCheckerNature.NATURE_ID)) {
                 IScopeContext context = new ProjectScope(project);
                 projectPreferences = context.getNode(CodeCheckerNature.NATURE_ID);
-            }
+            } 
         } catch (CoreException e) {
-            Logger.log(IStatus.ERROR, "" + e);
-            Logger.log(IStatus.INFO, "" + e.getStackTrace());
+            Logger.log(IStatus.ERROR, e.getMessage());
+            Logger.log(IStatus.INFO, e.getStackTrace().toString());
+            return;
         }
     }
 
-    public void modifyProjectEnvironmentVariables(final Map<String, String> environmentAdd) {
-        if (project!=null){
-            IContributedEnvironment ice = CCorePlugin.getDefault().getBuildEnvironmentManager()
-                    .getContributedEnvironment();
-            //we assume that the project is CDT
-            ICProjectDescription prjd = CoreModel.getDefault().getProjectDescription(project, true); 
-            ICConfigurationDescription cfgd = prjd.getActiveConfiguration();
-            for(String key : environmentAdd.keySet()) {
-                if(key.equals("PATH")) {
-                    ice.addVariable(key, environmentAdd.get(key), IEnvironmentVariable.ENVVAR_PREPEND,"", cfgd);
-                } else {
-                    ice.addVariable(key, environmentAdd.get(key), IEnvironmentVariable.ENVVAR_REPLACE,"", cfgd);
+    /**
+     * Stores Project level loaded preferences.
+     */
+    private void storeLoadedPreferences(){
+        commonProjectConfig = new HashMap<>();
+        projectOnlyConfig = new HashMap<>();
+        try {
+            for (String configKey : projectPreferences.keys()) {
+                ConfigTypes ct = ConfigTypesCommon.GetFromString(configKey);
+                if (ct != null)
+                    commonProjectConfig.put((ConfigTypesCommon)ct, projectPreferences.get(configKey, STR_EMPTY));
+                else {
+                    ct = ConfigTypesProject.GetFromString(configKey);
+                    if (ct != null) 
+                    	projectOnlyConfig.put((ConfigTypesProject)ct, projectPreferences.get(configKey, STR_EMPTY));
                 }
             }
-            try {
-                CoreModel.getDefault().setProjectDescription(project, prjd);
-            } catch (CoreException e) {
-                Logger.log(IStatus.ERROR, "" + e);
-                Logger.log(IStatus.INFO, "" + e.getStackTrace());
+            if (!projectOnlyConfig.containsKey(ConfigTypesProject.IS_GLOBAL)) {
+                projectOnlyConfig.put(ConfigTypesProject.IS_GLOBAL, TRUE);
             }
-        }
-    }
-
-    /*public String getServerUrl() {
-        try {
-            return CodeCheckerContext.getInstance().getServerObject(project).getServerUrl();
-        } catch (Exception e) {
-            return "";
-        }
-    }*/
-
-    public IEclipsePreferences getActivePreferences(){
-        if (project!=null && !isGlobal() )
-            return 
-                    projectPreferences;
-        else
-            return
-                    globalPreferences;
-    }
-
-    public IEclipsePreferences getGlobalPreferences(){
-        return globalPreferences;
-    }
-
-
-    public Map<ConfigTypes, String> getConfig() {
-        if (project!=null && !isGlobal()){
-            Logger.log(IStatus.INFO, "returning project config");
-            return getConfigEclipse(projectPreferences);
-        }
-        else{
-            Logger.log(IStatus.INFO, "returning global config");
-            return getConfigEclipse(globalPreferences);            
-        }
-
-    }
-
-    public Map<ConfigTypes, String> getDefaultConfig() {
-        Map<ConfigTypes, String> ret = new HashMap<ConfigTypes, String>();
-        for (ConfigTypes k:ConfigTypes.values()){
-            if (defaults.containsKey(k))
-                ret.put(k,defaults.get(k));
-            else
-                ret.put(k,"");
-        }
-        return ret;
-    }
-
-    private  Map<ConfigTypes, String> getConfigEclipse(IEclipsePreferences pref ) {
-        Map<ConfigTypes, String> ret = new HashMap<ConfigTypes, String>();
-        for (ConfigTypes k:ConfigTypes.values()){
-            if (defaults.containsKey(k))
-                ret.put(k,defaults.get(k));
-            else
-                ret.put(k,"");
-        }
-
-        try {
-            for (String configKey : pref.keys()) {
-                for (ConfigTypes c : configKeys.keySet()) {
-                    if (configKey.equals(configKeys.get(c))){
-                        ret.put(c, pref.get(configKey, ""));
-                    }
-                }
-            }
+            useGlobal = Boolean.parseBoolean(projectOnlyConfig.get(ConfigTypesProject.IS_GLOBAL));
         } catch (BackingStoreException e) {
+            e.printStackTrace();
         }
-
-
-        return ret;
     }
 
 
-    public void dumpConfig(Map<ConfigTypes, String> config) {
-        Logger.log(IStatus.INFO, "Config:");
+    /**
+     * Returns preferences related to this project.
+     * @param global If null the procets internal boolean decides which to return.
+     * @return The config.
+     */
+    public Map<ConfigTypes, String> getProjectConfig(Boolean global) {
+        Map<ConfigTypes, String> retConfig = new HashMap<>();
+        retConfig.putAll(projectOnlyConfig);
+        if (global == null) {
+            if (useGlobal){
+                retConfig.putAll(globalConfig);
+            } else {
+                retConfig.putAll(commonProjectConfig);
+            }
+            return retConfig;
+        } else { // if we want the projects choice
+            if (global){
+                retConfig.putAll(globalConfig);
+            } else {
+                retConfig.putAll(commonProjectConfig);
+            }
+            return retConfig;
+        }
+    }
+
+    /**
+     * Returns the default config for the plugin. 
+     * @return An Unmodifiable view of the default config Map.
+     */
+    public Map<ConfigTypes, String> getDefaultConfig() {
+        return Collections.unmodifiableMap(DEFAULT_CONFIG);
+    }
+
+
+    /**
+     * Logs the given configuration to Error Log.
+     * @param config The config to be logged
+     */
+    public void logConfig(Map<ConfigTypes, String> config) {
+        StringBuilder sb = new StringBuilder();
         for (Map.Entry<ConfigTypes, String> entry : config.entrySet()) {
-            Logger.log(IStatus.INFO, configKeys.get(entry.getKey()) + ":" + entry.getValue());
+            sb.append(entry.getKey() + SEP + entry.getValue() + System.lineSeparator());
         }
+        Logger.log(IStatus.INFO, "Config: " + sb.toString());
     }
 
+    /**
+     * Returns if a project uses the global configuration.
+     * @return True if global, false if not.
+     */
     public boolean isGlobal() {
-        if (project!=null)
-            return (projectPreferences.get(configKeys.get(ConfigTypes.IS_GLOBAL), "true").equals("true"));
-        else
-            return true;
+        return useGlobal;
     }
 
-    public void updateProject(Map<ConfigTypes,String> newConfig){
-        for (Map.Entry<ConfigTypes, String> entry : newConfig.entrySet())
-        {            
-            Logger.log(IStatus.INFO, "updateProject(): " + configKeys.get(entry.getKey()) +":"+entry.getValue());
-            projectPreferences.put(configKeys.get(entry.getKey()), entry.getValue());
+    /**
+     * Updates the config.
+     * @param config The new config to be saved.
+     */
+    public void updateProjectConfig(Map<ConfigTypes,String> config){
+        StringBuilder log = new StringBuilder();
+        for (Map.Entry<ConfigTypes, String> entry : config.entrySet())
+        {    
+            log.append(entry.getKey().toString() + SEP + entry.getValue() + System.lineSeparator());
+            projectPreferences.put(entry.getKey().toString(), entry.getValue());
         }
+        Logger.log(IStatus.INFO, log.toString());
         try {
             projectPreferences.flush();
+            storeLoadedPreferences();
             updateServer(CodeCheckerContext.getInstance().getServerObject(project));
         } catch (BackingStoreException e) {
+            Logger.log(IStatus.ERROR, e.getMessage());
+            e.printStackTrace();
         }    	
     }
 
-
-    //updates configuration in eclipse
-    //and restarts the corresponding CodeChecker server(s)
-    public void updateConfig(Map<ConfigTypes, String> newConfig) {        
-        if (project==null){//updating global configuration and all running servers
-            for (Map.Entry<ConfigTypes, String> entry : newConfig.entrySet()) {            
-                Logger.log(IStatus.INFO, "updateGlobal(): " + configKeys.get(entry.getKey()) + ":" + entry.getValue());
-                globalPreferences.put(configKeys.get(entry.getKey()), entry.getValue());
-            }
-
-            IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-            for (IProject project : projects) {
-                try {
-                    if (project.hasNature(CodeCheckerNature.NATURE_ID) && isCDTProject(project) ) {
-                        CcConfiguration cc = new CcConfiguration(project);
-                        if (cc.isGlobal()) {
-                            cc.updateServer(CodeCheckerContext.getInstance().getServerObject(project));
-                        }
-                    }
-                } catch (CoreException e) {
-                    // TODO Auto-generated catch block
-                }
-            }
-            try {
-                globalPreferences.flush();
-            } catch (BackingStoreException e) {
-            }
-        }else{//updating the config of the current project only
-            for (Map.Entry<ConfigTypes, String> entry : newConfig.entrySet())
-            {            
-                Logger.log(IStatus.INFO, "updateProject(): " + configKeys.get(entry.getKey()) +":"+entry.getValue());
-                projectPreferences.put(configKeys.get(entry.getKey()), entry.getValue());
-            }
-            try {
-                projectPreferences.flush();
-                updateServer(CodeCheckerContext.getInstance().getServerObject(project));
-            } catch (BackingStoreException e) {
-            }       
-        }
-    }
-
-    public static boolean isCDTProject(IProject p){
-        return CoreModel.getDefault().getProjectDescription(p, true)!=null;
-    }
-
+    /**
+     * Return File location relative  to project location.
+     * @param projectRelativeFile The file in question.
+     * @return The location.
+     */
     public String convertFilenameToServer(String projectRelativeFile) {
         return getLocationPrefix() + projectRelativeFile;
     }
 
+    /**
+     * Gets the projects containing folder on disk.
+     * @return The projects location with an / appended.
+     */
     public String getLocationPrefix() {
-        // TODO Auto-generated method stub
         return project.getLocation().toOSString() + "/";
     }
 
+    /**
+     * Strips path from file location.
+     * @param serverFile Only the filename needed from this.
+     * @return Filename stripped of it's path prefix.
+     */
     public String convertFilenameFromServer(String serverFile) {
-        if (getLocationPrefix().equals("")) {
+        if (getLocationPrefix().equals(STR_EMPTY)) {
             return serverFile;
         }
-        return serverFile.replace(getLocationPrefix(), "");
+        return serverFile.replace(getLocationPrefix(), STR_EMPTY);
     }
 
-    public boolean isConfigured() {
-        try {
-            if(project!=null && project.hasNature(CodeCheckerNature.NATURE_ID)&& isCDTProject(project) ) {
-            	return true;
-                /*CodeCheckEnvironmentChecker ccec = CodeCheckerContext.getInstance().getServerObject(project)
-                        .getCodecheckerEnvironment();
-                if (ccec != null) {
-                    int port=CodeCheckerContext.getInstance().getServerObject(project).serverPort;
-                    Logger.log(IStatus.INFO, "checking codechecker on port"+port);
-                    return ccec.isJavaRunner(port);
-                }else
-                    Logger.log(IStatus.INFO, "CodeCheckerContext is null!");
-                return false;*/
-            }
-            return false;
-        } catch (CoreException e) {
-            return false;
+    /**
+     * Checks if the CodeChecker working directory exists, and creates it if not.
+     */
+    public void checkCodeCheckerReportDir() {
+        File ccWorkDir = new File(CODECHECKER_WORKSPACE);
+        if (!ccWorkDir.exists()) {
+            Boolean b = ccWorkDir.mkdir();
+            Logger.log(IStatus.INFO, "Making cc directory " + b);
+        }
+        File workDir = new File(projectOnlyConfig.get(ConfigTypesProject.CHECKER_WORKSPACE));
+        if (!workDir.exists()) {
+            Boolean b = workDir.mkdir();
+            Logger.log(IStatus.INFO, "Making directory " + b);
         }
     }
 
+    /**
+     * TODO Will be deleted in next patch.
+     * @param server .
+     */
     public void updateServer(CodecheckerServerThread server) {
         if (project!=null){
             Logger.log(IStatus.INFO, "Updating Server" + project.getName());
-            Map<ConfigTypes, String> config = getConfig();		
-            config.put(ConfigTypes.CHECKER_WORKSPACE, ResourcesPlugin.getWorkspace().getRoot().getLocation().toString()
-                    + "/.codechecker/" + project.getName());// codechecker workspace
-            dumpConfig(config);
-            try {
-            	File ccWorkDir = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() + "/.codechecker");
-                if (!ccWorkDir.exists()) {
-                    Boolean b = ccWorkDir.mkdir();
-                    Logger.log(IStatus.INFO, "Making cc directory " + b);
-                }
-                File workDir = new File(ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() + "/.codechecker/"
-                        + project.getName());
-                if (!workDir.exists()) {
-                    Boolean b = workDir.mkdir();
-                    Logger.log(IStatus.INFO, "Making directory " + b);
-                }
-                Logger.log(IStatus.INFO, "Restarting server : " + project.getName());
-                CodeCheckEnvironmentChecker ccec = new CodeCheckEnvironmentChecker(config);
-                //ccec.setServerPort(server.serverPort);
-                modifyProjectEnvironmentVariables(ccec.getEnvironmentAddList());
-                server.setCodecheckerEnvironment(ccec);
-                //ConsoleFactory.consoleWrite(
-                //        project.getName() + ":  CodeChecker server listening on port: " + server.serverPort);
+            CodeCheckEnvironmentChecker ccec = new CodeCheckEnvironmentChecker(getProjectConfig(null));
+            server.setCodecheckerEnvironment(ccec);
+        }
+    }
 
-            } catch (Exception e) {
-                ConsoleFactory.consoleWrite(project.getName() + ": Failed to start server " + e.getStackTrace().toString());            
-                e.printStackTrace();
-                Logger.log(IStatus.ERROR, "" + e);
-                Logger.log(IStatus.INFO, "" + e.getStackTrace());
+    /**
+     * Adds to build environment variables, to be able to log the compilation commands with lldb.
+     * @param environmentAdd
+     */
+    public void modifyProjectEnvironmentVariables() {
+        CodeCheckEnvironmentChecker ccec = new CodeCheckEnvironmentChecker(getProjectConfig(null));
+        final Map<String, String> environmentAdd = ccec.getEnvironmentAddList();
+        if (project!=null){
+            IContributedEnvironment ice = CCorePlugin.getDefault().getBuildEnvironmentManager()
+                .getContributedEnvironment();
+            //we assume that the project is CDT
+            ICProjectDescription prjd = CoreModel.getDefault().getProjectDescription(project, true); 
+            ICConfigurationDescription cfgd = prjd.getActiveConfiguration();
+            StringBuilder sb = new StringBuilder();
+            for(String key : environmentAdd.keySet()) {
+                sb.append(key + SEP + environmentAdd.get(key) + System.lineSeparator());
+                if("PATH".equals(key)) {
+                    ice.addVariable(key, environmentAdd.get(key),
+                            IEnvironmentVariable.ENVVAR_PREPEND, STR_EMPTY, cfgd);
+                } else {
+                    ice.addVariable(key, environmentAdd.get(key),
+                            IEnvironmentVariable.ENVVAR_REPLACE, STR_EMPTY, cfgd);
+                }
             }
+            Logger.log(IStatus.INFO, "Added Variables: " + sb.toString());
+            try {
+                CoreModel.getDefault().setProjectDescription(project, prjd);
+            } catch (CoreException e) {
+                Logger.log(IStatus.ERROR, e.getMessage());
+                Logger.log(IStatus.INFO, e.getStackTrace().toString());
+            }
+        }
+    }
+
+    /**
+     * @return The global config.
+     */
+    public static Map<ConfigTypes, String> getGlobalConfig() {
+        return globalConfig;
+    }
+
+    /**
+     * Initializes the plugins internal config, Call this method somewhere early.
+     */
+    public static void initGlobalConfig() {
+    	Logger.log(IStatus.INFO, Collections.unmodifiableMap(DEFAULT_CONFIG).getClass().toString());
+        globalPreferences = ConfigurationScope.INSTANCE.getNode(CodeCheckerNature.NATURE_ID);
+        validatePersistentGlobalPreferences();
+        globalConfig = new ConcurrentHashMap<>();
+        try {
+            StringBuilder log = new StringBuilder();
+            for (String configKey : globalPreferences.keys()) {
+                ConfigTypes ct = ConfigTypesCommon.GetFromString(configKey);
+                if (ct != null) globalConfig.put(ct, globalPreferences.get(configKey, STR_EMPTY));
+                log.append(configKey + SEP + globalPreferences.get(configKey, STR_EMPTY) + System.lineSeparator());
+            }
+            Logger.log(IStatus.INFO, System.lineSeparator() + log.toString());
+        } catch (BackingStoreException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Validates global preferences of the plugin.
+     */
+    private static void validatePersistentGlobalPreferences() {
+        if (globalPreferences != null) {
+            try {
+                Set<String> storedGlobalPrefs = Sets.newHashSet(globalPreferences.keys());
+                StringBuilder log = new StringBuilder();
+                //These are the valid config keys.
+                for (Map.Entry<ConfigTypes, String> entry : DEFAULT_CONFIG.entrySet()) {
+                    //if the key doesn't exist in preferences, put the corresponding kv in.
+                    if (!storedGlobalPrefs.contains(entry.getKey().toString())){
+                        globalPreferences.put(entry.getKey().toString(), entry.getValue());
+                        log.append(entry.getKey().toString() + SEP + entry.getValue() + System.lineSeparator());
+                    }
+
+                }
+                Logger.log(IStatus.WARNING, "Missing keys in global config were:" + System.lineSeparator() 
+                    + log.toString());
+                globalPreferences.flush(); // flush only saves changes, so no need for a change flag.
+            } catch (BackingStoreException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Updates both persistent and in memory representation of global config.
+     * @param newConfig The new config to be flushed.
+     */
+    public static void updateGlobalConfig(Map<ConfigTypes, String> newConfig) {
+        globalConfig = newConfig;
+        for (Map.Entry<ConfigTypes, String> entry : newConfig.entrySet()) {            
+            globalPreferences.put(entry.getKey().toString(), entry.getValue());
+        }
+        try {
+            globalPreferences.flush();
+        } catch (BackingStoreException e) {
+            Logger.log(IStatus.ERROR, e.getMessage());
         }
     }
 }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/Config.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/Config.java
@@ -1,9 +1,34 @@
 package cc.codechecker.plugin.config;
 
 public class Config {
-    public enum ConfigTypes {
-        CHECKER_PATH, PYTHON_PATH, COMPILERS, ANAL_THREADS,
-        CHECKER_LIST,IS_GLOBAL,CHECKER_WORKSPACE
-    }
+	public interface ConfigTypes {}
+	
+    public enum ConfigTypesCommon implements ConfigTypes {
+        CHECKER_PATH, 
+        PYTHON_PATH, 
+        COMPILERS, 
+        ANAL_THREADS,
+        CHECKER_LIST;
 
+		public static ConfigTypes GetFromString(String s) {
+			for (ConfigTypes c :ConfigTypesCommon.values()) {
+				if (s.equals(c.toString())) 
+					return c;
+			}
+			return null;
+		}
+    }
+    
+    public enum ConfigTypesProject implements ConfigTypes {
+    	IS_GLOBAL, 
+    	CHECKER_WORKSPACE;
+    	
+		public static ConfigTypes GetFromString(String s) {
+			for (ConfigTypes c :ConfigTypesProject.values()) {
+				if (s.equals(c.toString())) 
+					return c;
+			}
+			return null;
+		}
+    }
 }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/package-info.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Configuration related package for the plugin.
+ * @author vodorok
+ */
+package cc.codechecker.plugin.config;

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/ProjectExplorerSelectionListener.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/ProjectExplorerSelectionListener.java
@@ -2,12 +2,14 @@ package cc.codechecker.plugin.init;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
 
+import cc.codechecker.plugin.CodeCheckerNature;
 import cc.codechecker.plugin.config.CodeCheckerContext;
 
 public class ProjectExplorerSelectionListener implements ISelectionListener{
@@ -20,8 +22,13 @@ public class ProjectExplorerSelectionListener implements ISelectionListener{
                 IResource resource = (IResource)((IAdaptable) element).getAdapter(IResource.class);
                 if (resource!=null){
                     final IProject project = resource.getProject();
-                    if (project!=null)
-                        CodeCheckerContext.getInstance().refreshChangeProject(project);
+                    try {
+						if (project!=null && project.hasNature(CodeCheckerNature.NATURE_ID))
+						    CodeCheckerContext.getInstance().refreshChangeProject(project);
+					} catch (CoreException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
                 }
             }
         }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/StartupJob.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/StartupJob.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import cc.codechecker.plugin.CodeCheckerNature;
+import cc.codechecker.plugin.config.CcConfiguration;
 import cc.codechecker.plugin.config.CodeCheckerContext;
 
 import cc.codechecker.plugin.Logger;
@@ -56,6 +57,8 @@ public class StartupJob extends Job {
 
         IWorkbench wb = PlatformUI.getWorkbench();
 
+        CcConfiguration.initGlobalConfig();
+        
         try { // TODO: find a better solution...
             Thread.sleep(2000);
         } catch (InterruptedException e) {
@@ -226,6 +229,10 @@ public class StartupJob extends Job {
             Logger.log(IStatus.INFO, "" + e.getStackTrace());
         }
         Logger.log(IStatus.INFO, "CodeChecker nature found!");
+        
+        CcConfiguration config = CodeCheckerContext.getInstance().getConfigForProject(project);
+        CodeCheckerContext.getInstance().setConfig(project, config);
+
         try {
             CodecheckerServerThread server = CodeCheckerContext.getInstance().getServerObject(project);
             // TODO Check if there is a better spot for this

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/runtime/CodeCheckEnvironmentChecker.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/runtime/CodeCheckEnvironmentChecker.java
@@ -1,6 +1,8 @@
 package cc.codechecker.plugin.runtime;
 
 import cc.codechecker.plugin.config.Config.ConfigTypes;
+import cc.codechecker.plugin.config.Config.ConfigTypesCommon;
+import cc.codechecker.plugin.config.Config.ConfigTypesProject;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
@@ -48,17 +50,17 @@ public class CodeCheckEnvironmentChecker {
 
     public CodeCheckEnvironmentChecker(Map<ConfigTypes,String> config_m) {
         config=config_m;
-        if (!config.containsKey(ConfigTypes.PYTHON_PATH) || (config.containsKey(ConfigTypes.PYTHON_PATH) && config.get(ConfigTypes.PYTHON_PATH).isEmpty())){
+        if (!config.containsKey(ConfigTypesCommon.PYTHON_PATH) || (config.containsKey(ConfigTypesCommon.PYTHON_PATH) && config.get(ConfigTypesCommon.PYTHON_PATH).isEmpty())){
             pythonEnvironment=Optional.absent();
             SLogger.log(LogI.INFO, "pythonenv is not set");
         }
         else{
             SLogger.log(LogI.INFO, "pythonenv is set to:"+config.get("PYTHON_PATH"));
-            pythonEnvironment=Optional.of(config.get(ConfigTypes.PYTHON_PATH));
+            pythonEnvironment=Optional.of(config.get(ConfigTypesCommon.PYTHON_PATH));
         }
 
-        checkerList=getConfigValue(ConfigTypes.CHECKER_LIST);
-        checkerDir=getConfigValue(ConfigTypes.CHECKER_PATH);
+        checkerList=getConfigValue(ConfigTypesCommon.CHECKER_LIST);
+        checkerDir=getConfigValue(ConfigTypesCommon.CHECKER_PATH);
         environmentBefore = getInitialEnvironment(pythonEnvironment);
         codeCheckerCommand = checkerDir+"/bin/CodeChecker";
 
@@ -68,9 +70,9 @@ public class CodeCheckEnvironmentChecker {
         environmentAddList = new HashMap<String, String>(){{
             put("LD_LIBRARY_PATH", checkerDir + "/ld_logger/lib");
             put("_", checkerDir + "/bin/CodeChecker");
-            put("CC_LOGGER_GCC_LIKE", getConfigValue(ConfigTypes.COMPILERS));
+            put("CC_LOGGER_GCC_LIKE", getConfigValue(ConfigTypesCommon.COMPILERS));
             put("LD_PRELOAD","ldlogger.so");
-            put("CC_LOGGER_FILE", getConfigValue(ConfigTypes.CHECKER_WORKSPACE) + "/compilation_commands.json.javarunner");
+            put("CC_LOGGER_FILE", getConfigValue(ConfigTypesProject.CHECKER_WORKSPACE) + "/compilation_commands.json.javarunner");
             put("CC_LOGGER_BIN", checkerDir + "/bin/ldlogger");
         }};
 
@@ -139,7 +141,7 @@ public class CodeCheckEnvironmentChecker {
     }
 
     public String getLogFileLocation() {
-        return getConfigValue(ConfigTypes.CHECKER_WORKSPACE) + "/compilation_commands.json.javarunner";
+        return getConfigValue(ConfigTypesProject.CHECKER_WORKSPACE) + "/compilation_commands.json.javarunner";
     }
 
     // renames the logfile, to avoid concurrency issues
@@ -155,37 +157,11 @@ public class CodeCheckEnvironmentChecker {
     }
 
     public String createAnalyzeCommmand(String buildLog){
-        return codeCheckerCommand + " analyze " + getConfigValue(ConfigTypes.CHECKER_LIST) + 
-       		 " -j "+ getConfigValue(ConfigTypes.ANAL_THREADS) + " -n javarunner" + 
-       		 " -o "+ getConfigValue(ConfigTypes.CHECKER_WORKSPACE)+"/results/ " + buildLog;
+        return codeCheckerCommand + " analyze " + getConfigValue(ConfigTypesCommon.CHECKER_LIST) + 
+       		 " -j "+ getConfigValue(ConfigTypesCommon.ANAL_THREADS) + " -n javarunner" + 
+       		 " -o "+ getConfigValue(ConfigTypesProject.CHECKER_WORKSPACE)+"/results/ " + buildLog;
    }
     
-  //TODO UPLIFT REMOVE
-/*
- *     
- *     drops codechecker Database
- *     
- */
-   /* public void dropDB(){        
-        String dbPath=getConfigValue(ConfigTypes.CHECKER_WORKSPACE)+"/codechecker.sqlite";        
-        SLogger.log(LogI.INFO,"Dropping database:"+dbPath);
-        File f = new File(dbPath);
-        if (f.isFile()){
-            if (!f.delete())
-                SLogger.log(LogI.ERROR,"Cannot delte CodeChecker DB. "+dbPath);
-        }
-        else
-            SLogger.log(LogI.ERROR,"Cannot delte CodeChecker DB. File not exists:"+dbPath);
-    }
-*/
-    
-//TODO UPLIFT REMOVE
-   /* public String createServerCommand(String port){
-        return codeCheckerCommand + " server --not-host-only -w " + 
-                getConfigValue(ConfigTypes.CHECKER_WORKSPACE) + " --view-port " + port;
-    }*/
-
-
     /**
      * Executes CodeChecker check command
      * on the build log received in the fileName parameter.

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/runtime/CodecheckerServerThread.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/runtime/CodecheckerServerThread.java
@@ -3,6 +3,7 @@ package cc.codechecker.plugin.runtime;
 import com.google.common.base.Optional;
 
 import cc.codechecker.plugin.config.Config.ConfigTypes;
+import cc.codechecker.plugin.config.Config.ConfigTypesCommon;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,8 +44,8 @@ public class CodecheckerServerThread {
         if (ccec!=null){
             Map<ConfigTypes, String> oldConfig = ccec.getConfig();
             Map<ConfigTypes, String> config=newEnv.getConfig();
-            if (config.get(ConfigTypes.CHECKER_PATH).equals(oldConfig.get(ConfigTypes.CHECKER_PATH))
-                    && config.get(ConfigTypes.PYTHON_PATH).equals(oldConfig.get(ConfigTypes.PYTHON_PATH)))
+            if (config.get(ConfigTypesCommon.CHECKER_PATH).equals(oldConfig.get(ConfigTypesCommon.CHECKER_PATH))
+                    && config.get(ConfigTypesCommon.PYTHON_PATH).equals(oldConfig.get(ConfigTypesCommon.PYTHON_PATH)))
                 restartNeeded = false;
         }
 

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/views/report/list/ReportListView.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/views/report/list/ReportListView.java
@@ -182,7 +182,7 @@ public class ReportListView extends ViewPart {
     }
 
     private void jumpToBugPosition(BugPathItem bpi) {
-        CcConfiguration config = new CcConfiguration(currentProject);
+        CcConfiguration config = CodeCheckerContext.getInstance().getConfigForProject(currentProject);
         String relName = config.convertFilenameFromServer(bpi.getFile());
         IFile fileinfo = currentProject.getFile(relName);
 


### PR DESCRIPTION
CcConfiguration has got a complete rewrite.
Major modifications including:

Global configuration:
- The global configuration is static and initialized on applicaton
    start in StartUpJob.
- Stripped project related fields IS_GLOBAL and CHECKER_WORKSPACE.

Project configuration:
- Constist of Common and Project type keys. Common is that exitst in
    Global, and Project related IS_GLOBAL and CHECKER_WORKSPACE which
    only has meaning in project context.
- Every project configuration is stored in CodeCheckerContext class. If not
    in the store, it's created. There is a list of classes that needed
    modification because before every time the configuration was needed
    a new instance was created. This was replaced with getting the
    stored config from CodeCheckerContext.
- Now Initialized on first access with current Global data, if it's a
    new project or read from persistent preferences.
- Logic which handles changing between Global or Project level configuration
    is different. Changing between them is now responsive. When set to
    Global the Projects Common values are ignored and the Global
    configuration is used. When Set to Project, the Common values are
    used.
- Project level configuration is first created at CodeCheckker Nature
    addition. This ensures that every eligible project has a
    configuration stored as persistent preferences, and a directory
    validation is also performed here.

Both type of configuration is validated when read from persistent
storage. If it's contains invalid or missing keys, it restores them with
default values from the default configuration.

The keys used in the preferences, are the actual enum keys stringified,
instead of strings associated with keys.

The CodeCheckEnvironmentChecker is now an utility class used by
CcConfiguration.

There is an enum poliformism introduced to help differentiate between
project and global keys. And an utility method is introduced to them
that returns if a config key is in that enum.

There is a minor Gui improvement regarding these changes:
- The project level config input fields are greyed and disabled when
    Global config is used.
- Form resizing works when parent window is resized.
- Proper border around input fields.

package-info.java was introduced according to chexkstyle rules.