### PR TITLE
Complete refactor of configuration.

### DIFF
--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/CodeCheckerNature.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/CodeCheckerNature.java
@@ -4,8 +4,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.CoreException;
 
+import cc.codechecker.plugin.config.CcConfiguration;
 import cc.codechecker.plugin.config.CodeCheckerContext;
-import cc.codechecker.plugin.runtime.CodecheckerServerThread;
 
 public class CodeCheckerNature implements IProjectNature {
 
@@ -14,7 +14,9 @@ public class CodeCheckerNature implements IProjectNature {
 
     @Override
     public void configure() throws CoreException {
-        CodecheckerServerThread server = CodeCheckerContext.getInstance().getServerObject(project);
+    	CcConfiguration config = new CcConfiguration(project);
+    	config.modifyProjectEnvironmentVariables();
+    	CodeCheckerContext.getInstance().setConfig(project, config);
     }
 
     @Override

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CodeCheckerContext.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CodeCheckerContext.java
@@ -5,15 +5,13 @@ import cc.codechecker.plugin.report.ReportParser;
 import cc.codechecker.plugin.report.SearchList;
 import cc.codechecker.plugin.runtime.CodecheckerServerThread;
 import cc.codechecker.plugin.runtime.OnCheckCallback;
-
 import cc.codechecker.plugin.views.report.list.ReportListView;
 import cc.codechecker.plugin.views.report.list.ReportListViewCustom;
 import cc.codechecker.plugin.views.report.list.ReportListViewListener;
 import cc.codechecker.plugin.views.report.list.ReportListViewProject;
 
-import com.google.common.base.Optional;
-
 import java.util.HashMap;
+import java.util.Map.Entry;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -25,7 +23,11 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 
+import cc.codechecker.plugin.CodeCheckerNature;
 import cc.codechecker.plugin.Logger;
+import cc.codechecker.plugin.config.Config.ConfigTypes;
+
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 /**
  * The Class CodeCheckerContext.
@@ -46,8 +48,28 @@ public class CodeCheckerContext {
     private HashMap<IProject, CodecheckerServerThread> servers = new HashMap<>();
 
     private HashMap<IProject, SearchList> reports = new HashMap<>();
+    
+    private HashMap<IProject, CcConfiguration> configs = new HashMap<>();
 
-    /** The active project. */
+    /**
+     * Returns a {@link CcConfiguration} object.
+     * .
+     * @param project The project in question.
+     * @return If there is no CcConfiguration stored, then creates a new instance.
+     */
+    public CcConfiguration getConfigForProject(IProject project) {
+    	if (!configs.containsKey(project)) 
+    		setConfig(project, new CcConfiguration(project));
+    	StringBuilder sb = new StringBuilder();
+        CcConfiguration.logConfig(configs.get(project).getProjectConfig(null));
+    	return configs.get(project);
+	}
+
+	public void setConfig(IProject project, CcConfiguration config) {
+		configs.put(project, config);
+	}
+
+	/** The active project. */
     private IProject activeProject = null;
 
     /** For storing in memory*/
@@ -237,11 +259,7 @@ public class CodeCheckerContext {
             return;
         }
 
-        CcConfiguration config = new CcConfiguration(project);
-        if (!config.isConfigured()) {
-            Logger.log(IStatus.INFO, "Codechecker not configured.");
-            return;
-        }
+        CcConfiguration config = getConfigForProject(project);
 
         //The actual refresh happens here.
         String filename = config.convertFilenameToServer(file.getProjectRelativePath().toString());
@@ -279,25 +297,28 @@ public class CodeCheckerContext {
             activeEditorPart = partRef;
             IFile file = ((IFileEditorInput) partRef.getEditorInput()).getFile();
             IProject project = file.getProject();
+            try {
+				if (project.hasNature(CodeCheckerNature.NATURE_ID)){
+				    CcConfiguration config = getConfigForProject(project);
 
-            CcConfiguration config = new CcConfiguration(project);
-            if (!config.isConfigured()) {
-                return;
-            }
+				    String filename = config.convertFilenameToServer(file.getProjectRelativePath().toString());
 
-            String filename = config.convertFilenameToServer(file.getProjectRelativePath().toString());
+				    IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+				    if(activeWindow == null) {
+				        Logger.log(IStatus.ERROR, " Error activeWindow is null!");
+				        return;
+				    }
+				    IWorkbenchPage[] pages = activeWindow.getPages();
 
-            IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
-            if(activeWindow == null) {
-                Logger.log(IStatus.ERROR, " Error activeWindow is null!");
-                return;
-            }
-            IWorkbenchPage[] pages = activeWindow.getPages();
-
-            this.refreshProject(pages, project, true);
-            this.refreshCurrent(pages, project, filename, true);
-            this.refreshCustom(pages, project, "", true);
-            this.activeProject = project;
+				    this.refreshProject(pages, project, true);
+				    this.refreshCurrent(pages, project, filename, true);
+				    this.refreshCustom(pages, project, "", true);
+				    this.activeProject = project;
+				}
+			} catch (CoreException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
         }
     }
 
@@ -358,8 +379,6 @@ public class CodeCheckerContext {
     public void runReportJob(ReportListView target, String currentFileName) {
         IProject project = target.getCurrentProject();
         if (project == null) return;
-        CcConfiguration config = new CcConfiguration(project);
-        if (!config.isConfigured()) return;
         Logger.log(IStatus.INFO, "Started Filtering Reports for project: "+project.getName());
 
         // Dont Parse Here just work from the reports Hasmap

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CommonGui.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/CommonGui.java
@@ -1,13 +1,14 @@
 package cc.codechecker.plugin.config;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -24,314 +25,421 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.forms.widgets.ColumnLayout;
 import org.eclipse.ui.forms.widgets.ExpandableComposite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.forms.widgets.Section;
 
-import com.google.common.base.Optional;
-
-import cc.codechecker.plugin.runtime.CodeCheckEnvironmentChecker;
-import cc.codechecker.plugin.config.CcConfiguration;
+import cc.codechecker.plugin.Logger;
 import cc.codechecker.plugin.config.Config.ConfigTypes;
-
 import cc.codechecker.plugin.itemselector.CheckerView;
+import cc.codechecker.plugin.runtime.CodeCheckEnvironmentChecker;
 import cc.codechecker.plugin.utils.CheckerItem;
 import cc.codechecker.plugin.utils.CheckerItem.LAST_ACTION;
 
-import cc.codechecker.plugin.Logger;
-import org.eclipse.core.runtime.IStatus;
-
+/**
+ * Global and project level preferences pages.
+ * @author vodorok
+ *
+ */
 public class CommonGui {
 
+    private static final String CC_BINARY = "/bin/CodeChecker";
+    private static final String VALID_PACKAGE = "CodeChecker package directory is valid";
+    private static final String INVALID_PACKAGE = "CodeChecker package directory is invalid";
+    private static final String BROSWE = "Browse";
+    private static final String CHECKER_ENABLED = " -e ";
+    private static final String CHECKER_DISABLED = " -d ";
+    private static final String CHECKER_SEPARATOR = " ";
 
-	boolean global;//whether this class is for global or project specific preferences
-	boolean useGlobalSettings;//if this is project specific page, whether to use global preferences 
-	IProject project;
-	CcConfiguration config;
-	private  Text codeCheckerDirectoryField;// codechecker dir
-	private  Text pythonEnvField;// CodeChecker python env
-	private  Text numThreads;// #of analysis threads
-	private  Text cLoggers;// #C compiler commands to catch
-	
-	private String checkerListArg = "";
-	private ScrolledForm form;
+    private static final int TEXTWIDTH = 200;
+    private static final int FORM_COLUMNS = 3;
 
-	private Button globalcc;
+    private boolean globalGui;// whether this class is for global or project
+                              // specific preferences
+    private boolean useGlobalSettings;// if this is project specific page,
+                                      // whether to use global preferences
+    private CcConfiguration config;
+    private Text codeCheckerDirectoryField;// codechecker dir
+    private Text pythonEnvField;// CodeChecker python env
+    private Text numThreads;// #of analysis threads
+    private Text cLoggers;// #C compiler commands to catch
+
+    private String checkerListArg = "";
+    private ScrolledForm form;
+
+    private Button globalcc;
     private Button projectcc;
-    //CodeCheckEnvironmentChecker checkerEnv=null;
-    //needs to be updated when codechecker dir or python env changes
     
-	public CommonGui(){		
-		global=true;
-		config=new CcConfiguration();
-	}
-	public CommonGui(IProject proj){		
-		project=proj;
-		config=new CcConfiguration(proj);
-		global=false;		       
-	}	
+    /**
+     * Constructor to be used, when only global preferences are to be set.
+     */
+    public CommonGui() {
+        globalGui = true;
+    }
 	
-	protected Text addTextField(FormToolkit toolkit, Composite comp, String labelText, String def) {
-		Text ret;
-		Label label = toolkit.createLabel(comp, labelText);
-		label.setLayoutData(new GridData());
-		ret = toolkit.createText(comp, def);
-		ret.setLayoutData(new GridData(GridData.FILL));
-		return ret;
-	}
+	/**
+	 * Constructor for setting project related preferences.
+	 * @param proj The project which preferences to be set
+	 */
+    public CommonGui(IProject proj) {
+        config = CodeCheckerContext.getInstance().getConfigForProject(proj);
+        useGlobalSettings = config.isGlobal();
+        globalGui = false;
+    }
+
+    /**
+     * Adds a {@link Text} input field with a {@link Label}.
+     * @param toolkit This toolkit is the factory that makes the Controls.
+     * @param comp The parent {@link Composite} that the new {@link Control} is to be added.
+     * @param labelText The text that will be added to the {@link Label}.
+     * @param def The default texdt thats displayed on the {@link Text}.
+     * @return The newly created textfield.
+     */
+    protected Text addTextField(FormToolkit toolkit, Composite comp, String labelText, String def) {
+        Text ret;
+        Label label = toolkit.createLabel(comp, labelText);
+        label.setLayoutData(new GridData());
+        ret = toolkit.createText(comp, def, SWT.MULTI | SWT.WRAP | SWT.BORDER);
+        GridData gd = new GridData();
+        gd.horizontalAlignment = GridData.FILL;
+        gd.grabExcessHorizontalSpace = true;
+        gd.widthHint = TEXTWIDTH;
+        ret.setLayoutData(gd);
+        return ret;
+    }
+
+    /**
+     * The actual creation of the controls happens in this method.
+     * Creates the {@link ScrolledForm} with a {@link FormToolkit}. This form is used as a canvas to add the input
+     * configuration fields for the global or project level configs. Also a global/project selector is added here
+     * when the class is constructed with a project.
+     * @param parent The parent which the form to be created on.
+     * @return The form itself.
+     */
+    public Control createContents(final Composite parent) {
+        final FormToolkit toolkit = new FormToolkit(parent.getDisplay());
+        form = toolkit.createScrolledForm(parent);
+
+        GridData ld = new GridData();
+        ld.verticalAlignment = GridData.FILL;
+        ld.horizontalAlignment = GridData.FILL;
+        ld.grabExcessHorizontalSpace = true;
+        ld.grabExcessVerticalSpace = true;
+        form.setLayoutData(ld);
+
+        ColumnLayout layout = new ColumnLayout();
+        layout.maxNumColumns = 1;
+        form.getBody().setLayout(layout);
+
+        Section globalConfigSection = null;
+        if (!globalGui) {
+            globalConfigSection = toolkit.createSection(form.getBody(), ExpandableComposite.EXPANDED);
+        }
+        final Section checkerConfigSection = toolkit.createSection(form.getBody(),
+                ExpandableComposite.TITLE_BAR | ExpandableComposite.TWISTIE | ExpandableComposite.EXPANDED);
+        checkerConfigSection.setEnabled(true);
+
+        final Composite client = toolkit.createComposite(checkerConfigSection);
+        client.setLayout(new GridLayout(FORM_COLUMNS, false));
+
+        checkerConfigSection.setClient(client);
+        checkerConfigSection.setText("Configuration");
+
+        codeCheckerDirectoryField = addTextField(toolkit, client, "CodeChecker package root directory", "");
+        codeCheckerDirectoryField.addListener(SWT.FocusOut, new Listener() {
+            @Override
+            public void handleEvent(Event event) {
+                try {
+                    Map<ConfigTypes, String> changedConfig = getConfigFromFields();
+                    CodeCheckEnvironmentChecker.getCheckerEnvironment(changedConfig,
+                            changedConfig.get(ConfigTypes.CHECKER_PATH) + CC_BINARY);
+                    form.setMessage(VALID_PACKAGE, IMessageProvider.INFORMATION);
+                } catch (IllegalArgumentException e1) {
+                    form.setMessage(INVALID_PACKAGE, IMessageProvider.ERROR);
+                }
+            }
+        });
+
+        final Button codeCheckerDirectoryFieldBrowse = new Button(client, SWT.PUSH);
+        codeCheckerDirectoryFieldBrowse.setText(BROSWE);
+        codeCheckerDirectoryFieldBrowse.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                DirectoryDialog dlg = new DirectoryDialog(client.getShell());
+                dlg.setFilterPath(codeCheckerDirectoryField.getText());
+                dlg.setText("Browse codechecker root");
+                String dir = dlg.open();
+                if (dir != null) {
+                    codeCheckerDirectoryField.setText(dir);
+                    try {
+                        Map<ConfigTypes, String> changedConfig = getConfigFromFields();
+                        CodeCheckEnvironmentChecker.getCheckerEnvironment(changedConfig,
+                                changedConfig.get(ConfigTypes.CHECKER_PATH) + CC_BINARY);
+                        form.setMessage(VALID_PACKAGE, IMessageProvider.INFORMATION);
+                    } catch (IllegalArgumentException e1) {
+                        form.setMessage(INVALID_PACKAGE, IMessageProvider.ERROR);
+                    }
+                }
+            }
+        });
+
+        pythonEnvField = addTextField(toolkit, client, "Python virtualenv root directory (optional)", "");
+        final Button pythonEnvFieldBrowse = new Button(client, SWT.PUSH);
+        pythonEnvFieldBrowse.setText(BROSWE);
+        pythonEnvFieldBrowse.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                DirectoryDialog dlg = new DirectoryDialog(client.getShell());
+                dlg.setFilterPath(codeCheckerDirectoryField.getText());
+                dlg.setText("Browse python environment");
+                String dir = dlg.open();
+                if (dir != null) {
+                    pythonEnvField.setText(dir);
+                }
+            }
+        });
+
+        numThreads = addTextField(toolkit, client, "Number of analysis threads", "4");
+        toolkit.createLabel(client, "");
+        cLoggers = addTextField(toolkit, client, "Compiler commands to log", "gcc:g++:clang:clang++");
+        toolkit.createLabel(client, "");
+
+        Map<ConfigTypes, String> configMap = loadConfig(false);
+        try {
+            CodeCheckEnvironmentChecker.getCheckerEnvironment(configMap,
+                    configMap.get(ConfigTypes.CHECKER_PATH) + CC_BINARY);
+            form.setMessage(VALID_PACKAGE, IMessageProvider.INFORMATION);
+        } catch (IllegalArgumentException e1) {
+            form.setMessage(INVALID_PACKAGE, IMessageProvider.ERROR);
+        }
+
+        final Button checkers = toolkit.createButton(client, "Toggle enabled checkers", SWT.PUSH);
+        checkers.addSelectionListener(new SelectionAdapter() {
+
+            public void widgetSelected(SelectionEvent e) {
+                Action action = new Action() {
+                    @Override
+                    public void run() {
+                        Shell activeShell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+                        Map<ConfigTypes, String> config = getConfigFromFields();
+                        try {
+                            CodeCheckEnvironmentChecker checkerEnv = new CodeCheckEnvironmentChecker(config);
+                            ArrayList<CheckerItem> checkersList = getCheckerList(checkerEnv);
+                            CheckerView dialog = new CheckerView(activeShell, checkersList);
+
+                            int result = dialog.open();
+
+                            if (result == 0) {
+                                checkerListArg = checkerListToCheckerListArg(dialog.getCheckersList());
+                            }
+                        } catch (IllegalArgumentException e) {
+                            Logger.log(IStatus.INFO, "Codechecker environment is invalid" + e);
+                        }
+                    }
+                };
+                action.run();
+            }
+        });
+        if (!globalGui) {
+            useGlobalSettings = config.isGlobal();
+            recursiveSetEnabled(checkerConfigSection, !useGlobalSettings);
+            final Composite client3 = toolkit.createComposite(globalConfigSection);
+            client3.setLayout(new GridLayout(2, true));
+            globalConfigSection.setClient(client3);
+            globalcc = toolkit.createButton(client3, "Use global configuration", SWT.RADIO);
+            globalcc.setSelection(useGlobalSettings);
+            globalcc.addSelectionListener(new SelectionAdapter() {
+                public void widgetSelected(SelectionEvent event) {
+                    recursiveSetEnabled(checkerConfigSection, false);
+                    useGlobalSettings = true;
+                    setFields(config.getProjectConfig(useGlobalSettings));
+                }
+            });
+            projectcc = toolkit.createButton(client3, "Use project configuration", SWT.RADIO);
+            projectcc.setSelection(!useGlobalSettings);
+            projectcc.addSelectionListener(new SelectionAdapter() {
+                public void widgetSelected(SelectionEvent event) {
+                    recursiveSetEnabled(checkerConfigSection, true);
+                    useGlobalSettings = false;
+                    setFields(config.getProjectConfig(useGlobalSettings));
+                }
+            });
+
+        }
+        return form.getBody();
+    }
+
+	/**
+	 * Recursive control state modifier.
+	 * If the control is {@link Composite} toggles it state and all of it's children {@link Control}.
+	 * @param control The parent control.
+	 * @param b The state to be set.
+	 */
+    public void recursiveSetEnabled(Control control, Boolean b) {
+        if (control instanceof Composite) {
+            Composite comp = (Composite) control;
+            for (Control c : comp.getChildren())
+                recursiveSetEnabled(c, b);
+        } else {
+            control.setEnabled(b);
+        }
+    }
+
+    /**
+     * Returns The all checkers from CodeChecker.
+     * @param ccec The Environment Checker to be used.
+     * @return A list of all available checkers.
+     */
+    private ArrayList<CheckerItem> getCheckerList(CodeCheckEnvironmentChecker ccec) {
+        // ArrayList<CheckerItem> defaultCheckersList = new ArrayList<>();
+        ArrayList<CheckerItem> checkersList = new ArrayList<>(); //
+        // new Checkers List
+        String s = ccec.getCheckerList();
+        String[] newCheckersSplit = s.split("\n");
+        // old Checkers Command
+        //String[] checkersCommand = checkerListArg.split(CHECKER_SEPARATOR);
+        //List<String> oldCheckersCommand = Arrays.asList(checkersCommand);
+        for (String it : newCheckersSplit) {
+            // String checkerName = it.split(" ")[2];
+            String checkerName = it;
+            CheckerItem check = new CheckerItem(checkerName);
+            boolean defaultEnabled = false;
+
+            if (it.split(CHECKER_SEPARATOR)[1].equals("+"))
+                defaultEnabled = true;
+            if (defaultEnabled) {
+                if (checkerListArg.contains(CHECKER_DISABLED + checkerName)) {
+                    check.setLastAction(LAST_ACTION.DESELECTION);
+                } else {
+                    check.setLastAction(LAST_ACTION.SELECTION);
+                }
+            } else {
+                if (checkerListArg.contains(CHECKER_ENABLED + checkerName)) {
+                    check.setLastAction(LAST_ACTION.SELECTION);
+                } else {
+                    check.setLastAction(LAST_ACTION.DESELECTION);
+                }
+            }
+            checkersList.add(check);
+        }
+        return checkersList;
+    }
+
+    /**
+     * Returns Stringified checkerlist configuration.
+     * @param chl The internal list of checkers.
+     * @return The string list of checkers prefixed with state.
+     */
+    protected String checkerListToCheckerListArg(List<CheckerItem> chl) {
+        StringBuilder checkerListArg = new StringBuilder();
+        for (int i = 0; i < chl.size(); ++i) {
+            if (chl.get(i).getLastAction() == LAST_ACTION.SELECTION)
+                checkerListArg.append(CHECKER_ENABLED + chl.get(i).getText() + CHECKER_SEPARATOR);
+            else
+                checkerListArg.append(CHECKER_DISABLED + chl.get(i).getText() + CHECKER_SEPARATOR);
+        }
+        return checkerListArg.toString();
+    }
+
+    /**
+     * Loads config from {@link CcConfiguration}.
+     * @param resetToDefault If set, the default config is used.
+     * @return The configuration map thats represent the preferences.
+     */
+    public Map<ConfigTypes, String> loadConfig(boolean resetToDefault) {
+        Map<ConfigTypes, String> ret = null;
+        if (!resetToDefault) {
+            if (globalGui)
+                ret = CcConfiguration.getGlobalConfig();
+            else {
+                ret = config.getProjectConfig(null);
+            }
+        } else
+            ret = config.getDefaultConfig();
+
+        setFields(ret);
+        return ret;
+    }
 	
-	public Control createContents(final Composite parent) {
-		final FormToolkit toolkit = new FormToolkit(parent.getDisplay());
-
-		form = toolkit.createScrolledForm(parent);
-		form.getBody().setLayout(new GridLayout());
-		Section  globalConfigSection=null;		
-		if (!global){					
-			globalConfigSection = toolkit.createSection(form.getBody(), ExpandableComposite.EXPANDED);			
-		}
-		final Section checkerConfigSection = toolkit.createSection(form.getBody(),
-				ExpandableComposite.TITLE_BAR | ExpandableComposite.TWISTIE | ExpandableComposite.EXPANDED);
-		checkerConfigSection.setEnabled(true);
-		
-		final Composite client = toolkit.createComposite(checkerConfigSection);
-		client.setLayout(new GridLayout(3,false));
-		checkerConfigSection.setClient(client);
-		checkerConfigSection.setText("Configuration");
-
-		codeCheckerDirectoryField = addTextField(toolkit, client, "CodeChecker package root directory", "");
-		codeCheckerDirectoryField.addListener(SWT.FocusOut, new Listener() {
-			@Override
-			public void handleEvent(Event event) {
-				try {
-					Map<ConfigTypes, String> changedConfig=getConfig();
-					CodeCheckEnvironmentChecker checkerEnv= new CodeCheckEnvironmentChecker(changedConfig);
-					form.setMessage("CodeChecker package directory is valid", 1);
-				} catch (IllegalArgumentException e1) {
-					form.setMessage("CodeChecker package directory is invalid", 3);					
-				}
-			}
-		});
-
-		final Button codeCheckerDirectoryFieldBrowse = new Button(client, SWT.PUSH);
-		codeCheckerDirectoryFieldBrowse.setText("Browse");
-		codeCheckerDirectoryFieldBrowse.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent event) {
-				DirectoryDialog dlg = new DirectoryDialog(client.getShell());
-				dlg.setFilterPath(codeCheckerDirectoryField.getText());
-				dlg.setText("Browse codechecker root");
-				String dir = dlg.open();
-				if (dir != null) {
-					codeCheckerDirectoryField.setText(dir);
-					try {
-						Map<ConfigTypes, String> changedConfig=getConfig();
-						CodeCheckEnvironmentChecker checkerEnv= new CodeCheckEnvironmentChecker(changedConfig);
-						form.setMessage("CodeChecker package directory is valid", 1);
-					} catch (IllegalArgumentException e1) {
-						form.setMessage("CodeChecker package directory is invalid", 3);
-					}
-				}
-			}
-		});
-
-		pythonEnvField = addTextField(toolkit, client, "Python virtualenv root directory (optional)", "");
-		final Button pythonEnvFieldBrowse = new Button(client, SWT.PUSH);
-		pythonEnvFieldBrowse.setText("Browse");
-		pythonEnvFieldBrowse.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent event) {
-				DirectoryDialog dlg = new DirectoryDialog(client.getShell());
-				dlg.setFilterPath(codeCheckerDirectoryField.getText());
-				dlg.setText("Browse python environment");
-				String dir = dlg.open();
-				if (dir != null) {
-					pythonEnvField.setText(dir);
-				}
-			}
-		});
-
-		numThreads = addTextField(toolkit, client, "Number of analysis threads", "4");
-		toolkit.createLabel(client, "");
-		cLoggers = addTextField(toolkit, client, "Compiler commands to log", "gcc:g++:clang");
-		toolkit.createLabel(client, "");
-		
-		Map<ConfigTypes, String> config=loadConfig(false);
-		try {			
-			CodeCheckEnvironmentChecker checkerEnv= new CodeCheckEnvironmentChecker(config);
-			form.setMessage("CodeChecker package directory is valid", 1);
-		} catch (Exception e1) {
-			form.setMessage("CodeChecker package directory is invalid", 3);					
-		}
+	/**
+	 * Sets the form fields with the given config maps values.
+	 * @param config The config which values are taken.
+	 */
+    public void setFields(Map<ConfigTypes, String> config) {
+        codeCheckerDirectoryField.setText(config.get(ConfigTypes.CHECKER_PATH));
+        pythonEnvField.setText(config.get(ConfigTypes.PYTHON_PATH));
+        checkerListArg = config.get(ConfigTypes.CHECKER_LIST);
+        cLoggers.setText(config.get(ConfigTypes.COMPILERS));
+        numThreads.setText(config.get(ConfigTypes.ANAL_THREADS));
+    }
 	
-		final Button checkers = toolkit.createButton(client, "Toggle enabled checkers", SWT.PUSH);
-		checkers.addSelectionListener(new SelectionAdapter() {
+    /**
+     * Returns a config map form the inputfields.
+     * @return The config map.
+     */
+    public Map<ConfigTypes, String> getConfigFromFields() {
+        Map<ConfigTypes, String> conf = new HashMap<>();
+        conf.put(ConfigTypes.CHECKER_PATH, codeCheckerDirectoryField.getText());
+        conf.put(ConfigTypes.PYTHON_PATH, pythonEnvField.getText());
+        conf.put(ConfigTypes.CHECKER_LIST, checkerListArg);
+        conf.put(ConfigTypes.ANAL_THREADS, numThreads.getText());
+        conf.put(ConfigTypes.COMPILERS, cLoggers.getText());
+        return conf;
+    }
 
-			public void widgetSelected(SelectionEvent e) {
-				Action action = new Action() {
-					@Override
-					public void run() {
-						Shell activeShell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
-						Map<ConfigTypes, String> config = getConfig();
-						try{
-							CodeCheckEnvironmentChecker checkerEnv = new CodeCheckEnvironmentChecker(config);
-							ArrayList<CheckerItem> checkersList=getCheckerList(checkerEnv);
-							CheckerView dialog = new CheckerView(activeShell, checkersList);
+    /**
+     * Updates persistent configuration through the {@link CcConfiguration}.
+     */
+    public void saveConfig() {
+        Map<ConfigTypes, String> conf = new HashMap<ConfigTypes, String>();
+        conf.put(ConfigTypes.CHECKER_PATH, codeCheckerDirectoryField.getText());
+        conf.put(ConfigTypes.PYTHON_PATH, pythonEnvField.getText());
+        conf.put(ConfigTypes.CHECKER_LIST, checkerListArg);
+        conf.put(ConfigTypes.ANAL_THREADS, numThreads.getText());
+        conf.put(ConfigTypes.COMPILERS, cLoggers.getText());
+
+        String g = "true";
+        if (!useGlobalSettings)
+            g = "false";
+        conf.put(ConfigTypes.IS_GLOBAL, g);
+        Logger.log(IStatus.INFO, "Saving project settings: IS_GLOBAL:" + g);
+
+        if (globalGui) {
+            CcConfiguration.updateGlobalConfig(conf);
+        } else {
+            config.updateProjectConfig(conf);
+        }
+    }
 	
-							int result = dialog.open();
-	
-							if (result == 0) {
-								checkerListArg=checkerListToCheckerListArg(dialog.getCheckersList());
-							}
-						}catch(IllegalArgumentException e){
-							Logger.log(IStatus.INFO, "Codechecker environment is invalid"+e);							
-						}						
-					}
-				};
-				action.run();
-			}
-		});
-		if (!global){										
-			checkerConfigSection.setEnabled(!useGlobalSettings);			
-			final Composite client3 = toolkit.createComposite(globalConfigSection);
-			client3.setLayout(new GridLayout(2, true));
-			globalConfigSection.setClient(client3);
-			globalcc = toolkit.createButton(client3, "Use global configuration", SWT.RADIO);
-			globalcc.setSelection(useGlobalSettings);
-			globalcc.addSelectionListener(new SelectionAdapter() {
-				public void widgetSelected(SelectionEvent event) {
-					checkerConfigSection.setEnabled(false);
-					useGlobalSettings=true;
-				}
-			});
-			projectcc = toolkit.createButton(client3, "Use project configuration", SWT.RADIO);
-			projectcc.setSelection(!useGlobalSettings);
-			projectcc.addSelectionListener(new SelectionAdapter() {
-				public void widgetSelected(SelectionEvent event) {
-					checkerConfigSection.setEnabled(true);
-					useGlobalSettings=false;
-				}
-			});
+    /**
+     * Used by preferences page.
+     */
+    public void performDefaults() {
+        loadConfig(true);
+    }
 
-		}
-		return form.getBody();
-	}
+    /**
+     * Used by preferences page.
+     * @return Always true.
+     */
+    public boolean isValid() {
+        return true;
+    }
 
-	private Optional<String> getPythonEnv() {
-		String s = this.pythonEnvField.getText();
-		if (s.isEmpty()) {
-			return Optional.absent();
-		} else {
-			return Optional.of(s);
-		}
-	}
+    /**
+     * Used by preferences page.
+     */
+    public void performOk() {
+        Logger.log(IStatus.INFO, "Saving!");
+        saveConfig();
+    }
 
-	private ArrayList<CheckerItem> getCheckerList(CodeCheckEnvironmentChecker ccec) {
-		// ArrayList<CheckerItem> defaultCheckersList = new ArrayList<>();
-		ArrayList<CheckerItem> checkersList = new ArrayList<>(); //
-		// new Checkers List
-		String s = ccec.getCheckerList();
-		String[] newCheckersSplit = s.split("\n");
-		// old Checkers Command
-		String[] checkersCommand = checkerListArg.split(" ");
-		List<String> oldCheckersCommand = Arrays.asList(checkersCommand);
-		for (String it : newCheckersSplit) {
-			//String checkerName = it.split(" ")[2];
-			String checkerName = it;
-			CheckerItem check = new CheckerItem(checkerName);
-			boolean defaultEnabled = false;
+    /**
+     * Used by preferences page.
+     * @param workbench The workbench thats used.
+     */
+    public void init(IWorkbench workbench) {
+        // TODO Auto-generated method stub
+    }
 
-			if (it.split(" ")[1].equals("+"))
-				defaultEnabled = true;
-			if (defaultEnabled) {
-				if (checkerListArg.contains(" -d " + checkerName)) {
-					check.setLastAction(LAST_ACTION.DESELECTION);
-				} else {
-					check.setLastAction(LAST_ACTION.SELECTION);
-				}
-			} else {
-				if (checkerListArg.contains(" -e " + checkerName)) {
-					check.setLastAction(LAST_ACTION.SELECTION);
-				} else {
-					check.setLastAction(LAST_ACTION.DESELECTION);
-				}
-			}
-			checkersList.add(check);
-		}		
-		return checkersList;
-	}
-
-	protected String checkerListToCheckerListArg(List<CheckerItem> chl) {
-		String checkerListArg="";
-		for (int i = 0; i < chl.size(); ++i) {
-			if (chl.get(i).getLastAction()==LAST_ACTION.SELECTION) 
-				checkerListArg+=(" -e " + chl.get(i).getText() + " ");
-			else
-				checkerListArg+=(" -d " + chl.get(i).getText() + " ");									
-		}		
-		return checkerListArg;		
-	}
-
-	public Map<ConfigTypes, String> loadConfig(boolean resetToDefault) {
-	    Map<ConfigTypes, String> ret;		
-	    if (!resetToDefault){
-	        ret=config.getConfig();
-	        useGlobalSettings = config.isGlobal();
-	    }
-	    else
-	        ret=config.getDefaultConfig();
-
-	    codeCheckerDirectoryField.setText(ret.get(ConfigTypes.CHECKER_PATH));
-	    pythonEnvField.setText(ret.get(ConfigTypes.PYTHON_PATH));
-	    checkerListArg = ret.get(ConfigTypes.CHECKER_LIST);
-	    cLoggers.setText(ret.get(ConfigTypes.COMPILERS));
-	    numThreads.setText(ret.get(ConfigTypes.ANAL_THREADS));
-	    return ret;
-	}
-	
-	public Map<ConfigTypes, String> getConfig() {				
-		Map<ConfigTypes, String> conf;				
-		conf = config.getConfig();		
-		conf.put(ConfigTypes.CHECKER_PATH, codeCheckerDirectoryField.getText());
-		conf.put(ConfigTypes.PYTHON_PATH, pythonEnvField.getText());
-		conf.put(ConfigTypes.CHECKER_LIST, checkerListArg);
-		conf.put(ConfigTypes.ANAL_THREADS, numThreads.getText());
-		conf.put(ConfigTypes.COMPILERS, cLoggers.getText());
-		return conf;
-	}
-
-	public void saveConfig() {				
-	    Map<ConfigTypes, String> conf=new HashMap<ConfigTypes,String>();						
-	    conf.put(ConfigTypes.CHECKER_PATH, codeCheckerDirectoryField.getText());
-	    conf.put(ConfigTypes.PYTHON_PATH, pythonEnvField.getText());
-	    conf.put(ConfigTypes.CHECKER_LIST, checkerListArg);
-	    conf.put(ConfigTypes.ANAL_THREADS, numThreads.getText());
-	    conf.put(ConfigTypes.COMPILERS, cLoggers.getText());
-
-	    String g="true";
-	    if (!useGlobalSettings)
-	        g="false";			
-	    conf.put(ConfigTypes.IS_GLOBAL, g);
-	    Logger.log(IStatus.INFO, "Saving project settings: IS_GLOBAL:"+g);			
-	    config.updateConfig(conf);				
-	}
-
-	public void performDefaults() {
-		loadConfig(true);
-	}
-	
-	public boolean isValid() {
-		return true;
-	}
-
-	
-	public void performOk() {
-		Logger.log(IStatus.INFO, "Saving!");
-		saveConfig();
-		
-	}
-
-	
-	public void init(IWorkbench workbench) {
-		// TODO Auto-generated method stub
-
-	}
 }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/Config.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/Config.java
@@ -1,9 +1,141 @@
 package cc.codechecker.plugin.config;
 
-public class Config {
-    public enum ConfigTypes {
-        CHECKER_PATH, PYTHON_PATH, COMPILERS, ANAL_THREADS,
-        CHECKER_LIST,IS_GLOBAL,CHECKER_WORKSPACE
-    }
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
+import org.eclipse.core.runtime.IStatus;
+
+import cc.codechecker.plugin.Logger;
+
+/**
+ * Classes for handling actual configuration entries, and logging.
+ * @author vodorok
+ *
+ */
+public class Config {
+    /**
+     * Represents all available configuraton values.
+     * Watch form marking comments, because specialized sets (Common, Project)
+     * are returned using enumset range,
+     * @author vodorok
+     *
+     */
+    public enum ConfigTypes {
+        // Common configuration values
+        CHECKER_PATH("codechecker_path"),
+        PYTHON_PATH("python_path"),
+        COMPILERS("gcc:g++:clang:clang++"),
+        ANAL_THREADS("4"),
+        CHECKER_LIST("enabled_checkers"),
+        // Project configuration values
+        IS_GLOBAL("true"),
+        CHECKER_WORKSPACE("codechecker_workdir");
+
+        public static Set<ConfigTypes> COMMON_TYPE = EnumSet.range(CHECKER_PATH, CHECKER_LIST);
+        public static Set<ConfigTypes> PROJECT_TYPE = EnumSet.range(IS_GLOBAL, CHECKER_WORKSPACE);
+        private String defaultValue;
+
+        /**
+         *
+         * @param def utility method for setting the default value.
+         */
+        private ConfigTypes(String def) {
+            this.defaultValue = def;
+        }
+
+        /**
+         *
+         * @return Returns the default value associated with the enum.
+         */
+        public String getDefaultValue() {
+            return defaultValue;
+        }
+
+        /**
+         *
+         * @param s The query string.
+         * @return The matching ConfigType if exists null otherwise.
+         */
+        public static ConfigTypes getFromString(String s) {
+            for (ConfigTypes c :ConfigTypes.values()) {
+                if (s.equals(c.toString()))
+                    return c;
+            }
+            return null;
+        }
+
+        /**
+         *
+         * @return Returns the default configuration values to the common configuration keys.
+         */
+        public static Map<ConfigTypes, String> getCommonDefault() {
+            Map<ConfigTypes, String> map = new HashMap<ConfigTypes, String>();
+            for (ConfigTypes ct : ConfigTypes.COMMON_TYPE)
+               map.put(ct, ct.defaultValue);
+            return map;
+        }
+    }
+    
+    /**
+     * Utility class for easier config logging.
+     * @author vodorok
+     *
+     */
+    public static class ConfigLogger {
+
+        public static final String SEP = "=";
+
+        private String header;
+        private StringBuilder messageBuilder;
+
+        /**
+         * Initializes the header with a message.
+         * @param header This will be the headline of the log.
+         */
+        public ConfigLogger(String header) {
+            this(header, IStatus.INFO);
+        }
+
+        /**
+         * Initializes the header with a message to be logged with, and
+         * a log level if something other is desired than ISTATUS.INFO.
+         * @param header This will be the headline of the log.
+         * @param info The log level thats used for logging.
+         */
+        public ConfigLogger(String header, int info) {
+            this.header = header + System.lineSeparator();
+        }
+
+        /**
+         * Called on first append for flagging log need.
+         */
+        public void init() { if (messageBuilder == null) messageBuilder = new StringBuilder(); }
+
+        /**
+         * Appends a String to the message.
+         * @param message Custom String.
+         */
+        public void append(String message){
+            init();
+            messageBuilder.append(message + System.lineSeparator());
+        }
+
+        /**
+         * Appends a stringified entry to the message.
+         * @param entry A {@link ConfigTypes} String pair.
+         */
+        public void append(Map.Entry<ConfigTypes, String> entry) {
+            init();
+            messageBuilder.append(entry.getKey() + SEP + entry.getValue() + System.lineSeparator());
+        }
+
+        /**
+         * Only logs when there is a message added.
+         */
+        public void log(){
+            if (messageBuilder != null ) Logger.log(IStatus.WARNING, header + messageBuilder.toString());
+        }
+    }
 }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/package-info.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/config/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Configuration related package for the plugin.
+ * @author vodorok
+ */
+package cc.codechecker.plugin.config;

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/ProjectExplorerSelectionListener.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/ProjectExplorerSelectionListener.java
@@ -2,12 +2,14 @@ package cc.codechecker.plugin.init;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
 
+import cc.codechecker.plugin.CodeCheckerNature;
 import cc.codechecker.plugin.config.CodeCheckerContext;
 
 public class ProjectExplorerSelectionListener implements ISelectionListener{
@@ -20,8 +22,13 @@ public class ProjectExplorerSelectionListener implements ISelectionListener{
                 IResource resource = (IResource)((IAdaptable) element).getAdapter(IResource.class);
                 if (resource!=null){
                     final IProject project = resource.getProject();
-                    if (project!=null)
-                        CodeCheckerContext.getInstance().refreshChangeProject(project);
+                    try {
+						if (project!=null && project.hasNature(CodeCheckerNature.NATURE_ID))
+						    CodeCheckerContext.getInstance().refreshChangeProject(project);
+					} catch (CoreException e) {
+						// TODO Auto-generated catch block
+						e.printStackTrace();
+					}
                 }
             }
         }

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/StartupJob.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/init/StartupJob.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import cc.codechecker.plugin.CodeCheckerNature;
+import cc.codechecker.plugin.config.CcConfiguration;
 import cc.codechecker.plugin.config.CodeCheckerContext;
 
 import cc.codechecker.plugin.Logger;
@@ -56,6 +57,8 @@ public class StartupJob extends Job {
 
         IWorkbench wb = PlatformUI.getWorkbench();
 
+        CcConfiguration.initGlobalConfig();
+        
         try { // TODO: find a better solution...
             Thread.sleep(2000);
         } catch (InterruptedException e) {
@@ -226,6 +229,10 @@ public class StartupJob extends Job {
             Logger.log(IStatus.INFO, "" + e.getStackTrace());
         }
         Logger.log(IStatus.INFO, "CodeChecker nature found!");
+        
+        CcConfiguration config = CodeCheckerContext.getInstance().getConfigForProject(project);
+        CodeCheckerContext.getInstance().setConfig(project, config);
+
         try {
             CodecheckerServerThread server = CodeCheckerContext.getInstance().getServerObject(project);
             // TODO Check if there is a better spot for this

--- a/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/views/report/list/ReportListView.java
+++ b/eclipse-plugin/eclipse/cc.codechecker.eclipse.plugin/src/cc/codechecker/plugin/views/report/list/ReportListView.java
@@ -182,7 +182,7 @@ public class ReportListView extends ViewPart {
     }
 
     private void jumpToBugPosition(BugPathItem bpi) {
-        CcConfiguration config = new CcConfiguration(currentProject);
+        CcConfiguration config = CodeCheckerContext.getInstance().getConfigForProject(currentProject);
         String relName = config.convertFilenameFromServer(bpi.getFile());
         IFile fileinfo = currentProject.getFile(relName);
 


### PR DESCRIPTION
ATTENTION: This commit got a lot of white space modification due to checkstyle. Please use ignore whitespace in diff settings,

This resolves #119

CcConfiguration has got a complete rewrite.
Major modifications including:

Global configuration:
- The global configuration is static and initialized on applicaton
    start in StartUpJob.
- Stripped project related fields IS_GLOBAL and CHECKER_WORKSPACE.

Project configuration:
- Constist of Common and Project type keys. Common is that exitst in
    Global, and Project related IS_GLOBAL and CHECKER_WORKSPACE which
    only has meaning in project context.
- Every project configuration is stored in CodeCheckerContext class. If not
    in the store, it's created. There is a list of classes that needed
    modification because before every time the configuration was needed
    a new instance was created. This was replaced with getting the
    stored config from CodeCheckerContext.
- Now Initialized on first access with current Global data, if it's a
    new project or read from persistent preferences.
- Logic which handles changing between Global or Project level configuration
    is different. Changing between them is now responsive. When set to
    Global the Projects Common values are ignored and the Global
    configuration is used. When Set to Project, the Common values are
    used.
- Project level configuration is first created at CodeCheckker Nature
    addition. This ensures that every eligible project has a
    configuration stored as persistent preferences, and a directory
    validation is also performed here.

Both type of configuration is validated when read from persistent
storage. If it's contains invalid or missing keys, it restores them with
default values from the default configuration.

Added clang++ to the default compiler list.

The keys used in the preferences, are the actual enum keys stringified,
instead of strings associated with keys.

The CodeCheckEnvironmentChecker is now an utility class used by
CcConfiguration. There is no instantiation on every preferences page
modification, instead a static method is called to perform the
CodeChecker binary validation.

The congfig enum is reworked. The String value associated with the actual
values, respresenst the default value of that key. And the default
config map is constructed here.
A utility method is introduced to that checks if a String is a valid
enum value, and returns that config key if true. Common and project related
enum specializations are implemented by range masking. There is a helper
method for easier logging of modified keys.

Unix path generation is replaced with a platform independent solution.

There is a minor Gui improvement regarding these changes:
- The project level config input fields are greyed and disabled when
    Global config is used.
- Form resizing works when parent window is resized.
- Proper border around input fields.

package-info.java was introduced according to chexkstyle rules.