### PR TITLE
Fixed pathSeparator misuse

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CcConfiguration.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CcConfiguration.java
@@ -228,7 +228,7 @@ public class CcConfiguration {
 
     /**
      * Gets the projects containing folder on disk.
-     * @return The projects location with platform independent pathSeparator appended to it.
+     * @return The projects location with system dependent name-separator appended to it.
      */
     public String getLocationPrefix() {
         return project.getLocation().toOSString() + File.separator;


### PR DESCRIPTION
The File.pathSeparator returns ":" but File.separator was needed "/".
Path separator was misused in the log file resolution, and in the
project environment setting.
Caused that only previously added projects behaved correctly, new ones
wouldn't have gotten analyzed.