### PR TITLE
Fixed commands with paths passed as String to process execution

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/CodeCheckEnvironmentChecker.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/CodeCheckEnvironmentChecker.java
@@ -1,16 +1,18 @@
 package org.codechecker.eclipse.plugin.runtime;
 
 import java.io.File;
+import java.util.HashMap;
 import java.util.Map;
 
+import org.codechecker.eclipse.plugin.Logger;
 import org.codechecker.eclipse.plugin.config.Config.ConfigTypes;
 import org.codechecker.eclipse.plugin.config.global.CcGlobalConfiguration;
 import org.codechecker.eclipse.plugin.config.project.CodeCheckerProject;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
-
 
 /**
  * This class checks for Environments used by CodeChecker.
@@ -18,16 +20,22 @@ import com.google.common.collect.ImmutableMap;
  */
 public class CodeCheckEnvironmentChecker {
 
+    private static final String CC_BINARY = "CC_BINARY";
+
+    private static final String HELP_ARGUMENT = "-h";
+    private static final int WAIT_TIME_MULTIPLYER = 1000; // in milliseconds
+    
     public final Optional<String> pythonEnvironment;
     public final String checkerDir; // root directory of CodeChecker
     public final String codeCheckerCommand; // CodecCheker executable path   
+
+    public final ImmutableMap<String, String> environmentBefore;
+
+    public Map<String, File> commandSubstitutionMap;
+
     private Map<ConfigTypes,String> config;
     private CodeCheckerProject project;
     private String checkerList;
-
-	//with specific python. This
-    // can be used to run CodeChecker
-    public final ImmutableMap<String, String> environmentBefore; 
 
     /**
      * 
@@ -49,7 +57,7 @@ public class CodeCheckEnvironmentChecker {
             SLogger.log(LogI.INFO, "pythonenv is not set");
         }
         else{
-            SLogger.log(LogI.INFO, "pythonenv is set to:"+config.get("PYTHON_PATH"));
+            SLogger.log(LogI.INFO, "pythonenv is set to:" + config.get(ConfigTypes.PYTHON_PATH));
             pythonEnvironment=Optional.of(config.get(ConfigTypes.PYTHON_PATH));
         }
 
@@ -57,6 +65,15 @@ public class CodeCheckEnvironmentChecker {
         checkerDir=getConfigValue(ConfigTypes.CHECKER_PATH);
         environmentBefore = getInitialEnvironment(pythonEnvironment);
         codeCheckerCommand = checkerDir+"/bin/CodeChecker";
+
+
+        commandSubstitutionMap = new HashMap<String, File>() {{
+                put("CC_BIN", new File(codeCheckerCommand));
+        }};
+        if (project != null)
+            commandSubstitutionMap.put("RESULTS",
+                    new File(project.getLogFileLocation().getParent().toString() + "/results/"));
+
     }
 
     /**
@@ -83,6 +100,7 @@ public class CodeCheckEnvironmentChecker {
      * @param config The Configuration to be used, 
      *              populated with {@link ConfigTypes}.
      * @param codeCheckerBinaryPath Path to CodeChecker.
+     * TODO This method doesn't need codeCheckerBinaryPath in its arguments as it's a field in this class.
      */
     public static void getCheckerEnvironment(
             Map<ConfigTypes, String> config, String codeCheckerBinaryPath) {
@@ -90,17 +108,23 @@ public class CodeCheckEnvironmentChecker {
         ShellExecutorHelper she = new ShellExecutorHelper(
                 getInitialEnvironment(Optional.of(config.get(ConfigTypes.PYTHON_PATH))));
 
-        String cmd=codeCheckerBinaryPath + " -h";
-        SLogger.log(LogI.INFO, "Testing " + cmd);
-        Optional<String> ccEnvOutput = she.quickReturnOutput(cmd);
+        String cmd = "'${CC_BINARY}' " + HELP_ARGUMENT;
+        @SuppressWarnings("serial")
+        Map<String, File> substitutinMap = new HashMap<String, File>() {{
+                put(CC_BINARY, new File(codeCheckerBinaryPath));
+        }};
+
+        SLogger.log(LogI.INFO, "Testing " + substitutinMap.get(CC_BINARY).getAbsolutePath() + " -h");
+        Optional<String> ccEnvOutput = she.quickReturnOutput(cmd, substitutinMap);
         double test = 0;
-        // WTF
+        // TODO WTF -- check the twisted logic behind this, and simplify.
         while(!ccEnvOutput.isPresent() && test <= 2){
-            ccEnvOutput = she.quickReturnOutput(cmd, Math.pow( 2.0 , test ) * 1000);
+            ccEnvOutput = she.quickReturnOutput(cmd, substitutinMap, Math.pow( 2.0 , test ) * WAIT_TIME_MULTIPLYER);
             ++test;
-        } 
+        }
         if (!ccEnvOutput.isPresent()) {
-            SLogger.log(LogI.ERROR, "Cannot run CodeChecker command:"+cmd);
+            SLogger.log(LogI.ERROR, "Cannot run CodeChecker command:" +
+                    substitutinMap.get(CC_BINARY).getAbsolutePath() + " " + HELP_ARGUMENT);
             throw new IllegalArgumentException("Couldn't run the specified CodeChecker for " +
                     "environment testing!");
         }
@@ -114,11 +138,13 @@ public class CodeCheckEnvironmentChecker {
     private static ImmutableMap<String, String> getInitialEnvironment(Optional<String> pythonEnvironment) {
         if (pythonEnvironment.isPresent()) {
             ShellExecutorHelper she = new ShellExecutorHelper(System.getenv());
-
-            Optional<String> output = she.quickReturnOutput("source " + pythonEnvironment.get() + "/bin/activate" + 
-                    " ; env");
+            File pyEnv = new File(pythonEnvironment.get() + "/bin/activate");
+            String cmd = "source '${PY_ENV}' ; env";
+            @SuppressWarnings("serial")
+            Map<String, File> substitutionMap = new HashMap<String, File>() {{ put("PY_ENV", pyEnv); }};
+            Optional<String> output = she.quickReturnOutput(cmd, substitutionMap);
             if (!output.isPresent()) {
-                SLogger.log(LogI.INFO, "SERVER_GUI_MSG >> Couldn't check the given python environment!");
+                Logger.log(IStatus.ERROR, "Couldn't check the python environment!");
                 throw new IllegalArgumentException("Couldn't check the given python environment!");
             } else {
                 ImmutableMap<String, String> environment = (new EnvironmentParser()).parse(output
@@ -151,40 +177,46 @@ public class CodeCheckEnvironmentChecker {
      * @param buildLog Path to the compile commands file, which the analyze command uses.
      * @return The constructed analyze command.
      */
-    public String createAnalyzeCommmand(String buildLog){
-        return codeCheckerCommand + " analyze " + getConfigValue(ConfigTypes.CHECKER_LIST) +
-             " -j "+ getConfigValue(ConfigTypes.ANAL_THREADS) + " -n javarunner" +
-             " -o "+ project.getLogFileLocation().getParent().toString() +"/results/ " + buildLog;
+    public String createAnalyzeCommmand(String buildLog) {
+        commandSubstitutionMap.put("LOG", new File(buildLog));
+        return "'${CC_BIN}' analyze " + getConfigValue(ConfigTypes.CHECKER_LIST) +
+                " -j "+ getConfigValue(ConfigTypes.ANAL_THREADS) + " -n javarunner" +
+                " -o " + "'${RESULTS}' " + "'${LOG}'";
     }
 
     /**
      * Executes CodeChecker check command
      * on the build log received in the fileName parameter.
-     * @param fileName Build log in the http://clang.llvm.org/docs/JSONCompilationDatabase.html format.
+     * @param buildLog Build log in the http://clang.llvm.org/docs/JSONCompilationDatabase.html format.
      * @param logToConsole Flag for indicating console logging
      * @param monitor ProgressMonitor for to be able to increment progress bar.
      * @param taskCount How many analyze step to be taken.
      * @return CodeChecker check command output
      */
-    public String processLog(String fileName, boolean logToConsole, IProgressMonitor monitor, int taskCount) {
+    public String processLog(String buildLog, boolean logToConsole, IProgressMonitor monitor, int taskCount) {
         ShellExecutorHelper she = new ShellExecutorHelper(environmentBefore);
-        String cmd = createAnalyzeCommmand(fileName);
-
+        String cmd = createAnalyzeCommmand(buildLog);
         SLogger.log(LogI.INFO, "SERVER_SER_MSG >> processLog >> "+ cmd);
-        //Optional<String> ccOutput = she.waitReturnOutput(cmd,logToConsole);
-        Optional<String> ccOutput = she.progressableWaitReturnOutput(cmd,logToConsole, monitor, taskCount);
+        Optional<String> ccOutput = she.progressableWaitReturnOutput(cmd, commandSubstitutionMap, logToConsole, monitor, taskCount);
         if (ccOutput.isPresent()) {
             // assume it succeeded, and delete the log file...
-            File f = new File(fileName);
+            File f = new File(buildLog);
             f.delete();
         }
         return ccOutput.or("");
     }
 
+    /**
+     * Returns the list of available checkers.
+     * Add the following for checker enability checking.
+     * CodeChecker checkers --details | cut -d " " -f "1-3"
+     * @return A String containing the checkers. One at a line.
+     */
     public String getCheckerList() {
         ShellExecutorHelper she = new ShellExecutorHelper(environmentBefore);
-        String cmd = codeCheckerCommand + " checkers";
-        Optional<String> ccOutput = she.waitReturnOutput(cmd,false);
+        String cmd = "'${CC_BIN}' checkers";
+        Optional<String> ccOutput = she.waitReturnOutput(cmd, commandSubstitutionMap, false);
         return ccOutput.or("");
     }
+
 }

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/CodeCheckerLocator.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/CodeCheckerLocator.java
@@ -34,7 +34,7 @@ public class CodeCheckerLocator {
     }
 
     private Optional<String> locateSystemCodeChecker() {
-        return shellExecutor.quickReturnFirstLine("/usr/bin/which CodeChecker");
+        return shellExecutor.quickReturnFirstLine("/usr/bin/which CodeChecker", null);
     }
 
 }

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/ShellExecutorHelper.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/runtime/ShellExecutorHelper.java
@@ -3,15 +3,20 @@ package org.codechecker.eclipse.plugin.runtime;
 import com.google.common.base.Optional;
 
 import org.apache.commons.exec.*;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jdt.annotation.Nullable;
 
 import java.io.*;
 import java.util.Map;
+import java.util.Vector;
 
 public class ShellExecutorHelper {
-	
-	
+
+    private static final int DEFAULT_TIMEOUT = 1000; // in milliseconds
+    private static final String WRAP_CHARACTER = "\"";
+
     final Map<String, String> environment;
 
     public ShellExecutorHelper(Map<String, String> environment) {
@@ -21,16 +26,17 @@ public class ShellExecutorHelper {
     /**
      * Executes the given bash script with a one sec time limit and returns it's first output line
      * from STDOUT.
-     *
-     * @param script Bash script, executed with bash -c "{script}"
-     * @return first line of the script's output
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
+     * @return The first line of the script's output in an Optional wrapper.
      */
-    public Optional<String> quickReturnFirstLine(String script) {
-        Executor ec = build(1000);
+    public Optional<String> quickReturnFirstLine(String cmd, @Nullable Map<String, File> substitutionMap) {
+        Executor ec = build(DEFAULT_TIMEOUT);
         try {
             OneLineReader olr = new OneLineReader();
             ec.setStreamHandler(new PumpStreamHandler(olr));
-            ec.execute(buildScriptCommandLine(script), environment);
+            ec.execute(buildScriptCommandLine(cmd, substitutionMap), environment);
             return olr.getLine();
         } catch (IOException e) {
             return Optional.absent();
@@ -39,29 +45,49 @@ public class ShellExecutorHelper {
 
     /**
      * Returns the full output.
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
+     * @return The script's output in an Optional wrapper.
      */
-    public Optional<String> quickReturnOutput(String script) {
-    	return this.quickReturnOutput(script, 1000);
+    public Optional<String> quickReturnOutput(String cmd, @Nullable Map<String, File> substitutionMap) {
+        return this.quickReturnOutput(cmd, substitutionMap, DEFAULT_TIMEOUT);
     }
     
-    public Optional<String> quickReturnOutput(String script, double timeOut) {
+    /**
+     * Returns the full output.
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
+     * @param timeOut The timeOut in Milliseconds.
+     * @return The script's output in an Optional wrapper.
+     */
+    public Optional<String> quickReturnOutput(String cmd, @Nullable Map<String, File> substitutionMap, double timeOut) {
         Executor ec = build(new Double(timeOut).longValue());
         try {
             AllLineReader olr = new AllLineReader();
             ec.setStreamHandler(new PumpStreamHandler(olr));
-            ec.execute(buildScriptCommandLine(script), environment);
+            ec.execute(buildScriptCommandLine(cmd, substitutionMap), environment);
             return Optional.of(olr.getOutput());
         } catch (IOException e) {
             return Optional.absent();
         }
     }
 
-    public Optional<String> waitReturnOutput(String script,boolean logToConsole) {
+    /**
+     * Returns the full output.
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
+     * @param logToConsole If true the execution log will appear on console log.
+     * @return The script's output in an Optional wrapper.
+     */
+    public Optional<String> waitReturnOutput(String cmd, @Nullable Map<String, File> substitutionMap, boolean logToConsole) {
         Executor ec = build();
         try {
             AllLineReader olr = new AllLineReader(logToConsole);
             ec.setStreamHandler(new PumpStreamHandler(olr));
-            ec.execute(buildScriptCommandLine(script), environment);
+            ec.execute(buildScriptCommandLine(cmd, substitutionMap), environment);
             return Optional.of(olr.getOutput());
         } catch (IOException e) {
             return Optional.absent();
@@ -70,20 +96,22 @@ public class ShellExecutorHelper {
 
     /**
      * Job {@link IProgressMonitor} compatible version of the standard
-     * {@link #waitReturnOutput(String,boolean) waitReturnOutput} method.
-     * @param script The string that will be executed.
+     * {@link #waitReturnOutput(String, Map, boolean) waitReturnOutput} method.
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
      * @param logToConsole If true the execution log will appear on console log.
      * @param monitor The progress monitor that can be incremented.
      * @param taskCount The number of separate jobs.
      * @return The process return value as a String wrapped in an @link {@link Optional}.
      */
-    public Optional<String> progressableWaitReturnOutput(String script,boolean logToConsole,
-            IProgressMonitor monitor, int taskCount) {
+    public Optional<String> progressableWaitReturnOutput(String cmd, @Nullable Map<String, File> substitutionMap,
+            boolean logToConsole, IProgressMonitor monitor, int taskCount) {
         Executor ec = build();
         try {
             AllLineReader olr = new ProgressableAllLineReader(logToConsole, monitor, taskCount);
             ec.setStreamHandler(new PumpStreamHandler(olr));
-            ec.execute(buildScriptCommandLine(script), environment);
+            ec.execute(buildScriptCommandLine(cmd, substitutionMap), environment);
             return Optional.of(olr.getOutput());
         } catch (IOException e) {
             return Optional.absent();
@@ -93,24 +121,35 @@ public class ShellExecutorHelper {
     /**
      * Executes the given bash script with a one sec time limit and returns based on it's exit
      * status.
-     *
-     * @param script Bash script, executed with bash -c "{script}"
+     * @param cmd Bash script, executed with bash -c "{script}".
+     * @param substitutionMap A <String, File> map for substituting the paths in the commands. use '${FILE}' for full
+     * compatibility.
      * @return true if successful
      */
-    public boolean quickAndSuccessfull(String script) {
-        Executor ec = build(1000);
+    public boolean quickAndSuccessfull(String cmd, @Nullable Map<String, File> substitutionMap) {
+        Executor ec = build(DEFAULT_TIMEOUT);
         try {
-            ec.execute(buildScriptCommandLine(script), environment);
+            ec.execute(buildScriptCommandLine(cmd, substitutionMap), environment);
             return true;
         } catch (IOException e) {
             return false;
         }
     }
 
-    private CommandLine buildScriptCommandLine(String script) {
-        CommandLine cl = new CommandLine("/bin/bash");
-        cl.addArgument("-c");
-        cl.addArgument(script, false);
+    /**
+     * Method for building Shell commands.
+     * @param cmd The raw command to be parsed. All file paths that's included in the command should be in the form of
+     *          ${FILE}, This way the path will be escaped correctly no matter what.
+     * @param substitutionMap The aforementioned ${FILE} has to have a value associated with it, FILE:{@link File}.
+     * @return The {@link CommandLine} object with proper escaping.
+     */
+    private CommandLine buildScriptCommandLine(String cmd, @Nullable Map<String, File> substitutionMap) {
+        StringBuilder sb = new StringBuilder("/bin/bash -c ");
+        sb.append(WRAP_CHARACTER);
+        sb.append(cmd);
+        sb.append(WRAP_CHARACTER);
+
+        CommandLine cl = fixCommandLine(CommandLine.parse(sb.toString(), substitutionMap));
         return cl;
     }
 
@@ -138,40 +177,6 @@ public class ShellExecutorHelper {
         int pid;
     }
 
-    /*public class Executable {
-        private final Executor executor;
-        private final CommandLine cmdLine;
-        private final PidObject pidObject;
-
-        public Executable(Executor executor, CommandLine cmdLine, PidObject pidObject) {
-            this.executor = executor;
-            this.cmdLine = cmdLine;
-            this.pidObject = pidObject;
-        }
-
-        public void kill() {
-        	SLogger.log(LogI.INFO, "SERVER_SER_MSG >> Killing PID " + this.pidObject.pid);
-            if (pidObject.pid > 1000) {
-                // Slightly less AWFUL BASH MAGIC, which gets the pids of the pidObject process and
-                //     all its descendant processes and kills them.
-                // The pidObject process should always be the main CodeChecker process this plugin
-                //     starts.
-        		String cpid = waitReturnOutput("echo $(ps -o pid= --ppid \"" + pidObject.pid + "\")",false).get().replace("\n", "");
-            	SLogger.log(LogI.INFO, "SERVER_SER_MSG >> Children CodeChecker PID is  " + cpid);
-            	try {
-            		waitReturnOutput("kill " + cpid,false);
-            	} catch(Exception e) {}
-            }
-        }
-
-        public void start() {
-            try {
-                executor.execute(cmdLine, environment);
-            } catch (IOException e) {
-            }
-        }
-    }
-*/
     class OneLineReader extends LogOutputStream {
 
         public Optional<String> line = Optional.absent();
@@ -271,6 +276,33 @@ public class ShellExecutorHelper {
 
             // TODO: log to file!
             SLogger.log(LogI.INFO, "SERVER_SER_MSG >> " + s);
+        }
+    }
+
+    /**
+     * Source: https://stackoverflow.com/a/45203609/8149485
+     * Fixes wonky apache Commandline parser, where quoting is enabled in the parser.
+     * @param badCommandLine {@link CommandLine} object with bad fields.
+     * @return The fixed {@link CommandLine} object.
+     */
+    public static CommandLine fixCommandLine(CommandLine badCommandLine) {
+        try {
+            CommandLine fixedCommandLine = new CommandLine(badCommandLine.getExecutable());
+            fixedCommandLine.setSubstitutionMap(badCommandLine.getSubstitutionMap());
+            Vector<?> arguments = (Vector<?>) FieldUtils.readField(badCommandLine, "arguments", true);
+            arguments.stream()
+                    .map(badArgument -> {
+                        try {
+                            return (String) FieldUtils.readField(badArgument, "value", true);
+                        } catch (IllegalAccessException e) {
+                            throw new RuntimeException(e);
+                        }
+                    })
+                    .forEach(goodArgument -> fixedCommandLine.addArgument(goodArgument, false));
+            return fixedCommandLine;
+        } catch (IllegalAccessException e) {
+            SLogger.log(LogI.ERROR, "Cannot fix bad command line");
+            return badCommandLine;
         }
     }
 }

--- a/tests/org.codechecker.eclipse.rcp.shared/resources/CodeChecker/bin/CodeChecker
+++ b/tests/org.codechecker.eclipse.rcp.shared/resources/CodeChecker/bin/CodeChecker
@@ -7,6 +7,17 @@ import sys
 import argparse
 
 """
+Handler function for the checker list.
+"""
+def checkers(args):
+    print(' core.uninitialized.Assign\n'+
+            ' cplusplus.NewDeleteLeaks\n'+
+            ' cplusplus.NewDelete\n'+
+            ' cppcoreguidelines-no-malloc\n'+
+            ' unix.Malloc\n'+
+            ' unix.MallocSizeof')
+
+"""
 Handler function for version information.
 """
 def version(args):
@@ -44,6 +55,10 @@ def main(args):
 
     """ For function extension add a new subparser and a 
     default handler function to it, for the simplest operation """
+    checkers_parser = subparsers.add_parser('checkers',
+        help="List the checkers available for code analysis.")
+    checkers_parser.set_defaults(func=checkers)
+
     version_parser = subparsers.add_parser('version',
         help="Print the version of CodeChecker package that is being used.")
     version_parser.set_defaults(func=version)

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/report/PlistParserTest.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/report/PlistParserTest.java
@@ -9,10 +9,10 @@ import org.eclipse.core.resources.IProject;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 public class PlistParserTest {
@@ -40,9 +40,4 @@ public class PlistParserTest {
         parser.parsePlist(file.toFile(), sl);
         assertThat(sl.getCheckers(), hasItem("alpha.core.SizeofPtr"));
     }
-
-    /*@Test
-    public void ParserTest2() {
-
-    }*/
 }

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/CodeCheckEnvironmentCheckerTest.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/CodeCheckEnvironmentCheckerTest.java
@@ -1,0 +1,97 @@
+package org.codechecker.eclipse.plugin.runtime;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.codechecker.eclipse.plugin.config.CcConfiguration;
+import org.codechecker.eclipse.plugin.config.CcConfigurationBase;
+import org.codechecker.eclipse.plugin.config.Config.ConfigTypes;
+import org.codechecker.eclipse.plugin.config.project.CodeCheckerProject;
+import org.codechecker.eclipse.rcp.shared.utils.Utils;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for CodeCheckEnvironmentChecker class.
+ */
+public class CodeCheckEnvironmentCheckerTest {
+
+    private static final String CODECHECKER = "CodeChecker";
+
+    /**
+     * The list of checkers that the stub Codechecker must return.
+     */
+    @SuppressWarnings("serial")
+    private static final Set<String> CHECKERS = new HashSet<String>() {{
+            add("core.uninitialized.Assign");
+            add("cplusplus.NewDeleteLeaks");
+            add("cplusplus.NewDelete");
+            add("cppcoreguidelines-no-malloc");
+            add("unix.Malloc");
+            add("unix.MallocSizeof");
+    }};
+
+    private Map<ConfigTypes,String> config;
+    private CodeCheckEnvironmentChecker ccec;
+
+    /**
+     * Check simple getCheckerList() commands succeeds.
+     */
+    @Test
+    public void codeCheckerCheckersCommandSucceds() {
+        // initialize the environment with CodeChecker installed in a "safe" directory
+        initEnvirCheck(CODECHECKER);
+        String checkers = ccec.getCheckerList();
+        assertThat(CHECKERS.stream().allMatch(str -> checkers.contains(str)), is(true));
+    }
+
+    /**
+     * Check more complex getCheckerList() commands succeeds.
+     */
+    @Test
+    public void codeCheckerCheckersCommandSuccedsComplex() {
+        // initialize the environment with CodeChecker installed in a "unsafe" directory
+        // (contains spaces and parenthesis)
+        initEnvirCheck("Code Che(c)ker");
+        String checkers = ccec.getCheckerList();
+        assertThat(CHECKERS.stream().allMatch(str -> checkers.contains(str)), is(true));
+    }
+
+    /**
+     * Initializes the configuration map and the environment checker.
+     * 
+     * @param dir
+     *            The directory where CodeChecker runnable will be placed
+     */
+    private void initEnvirCheck(String dir) {
+        Path testCCRoot = Utils.prepareCodeChecker(dir);
+        config = new HashMap<>();
+        config.put(ConfigTypes.CHECKER_PATH, testCCRoot.toString());
+
+        // Use mockito for mocking CodeCheckerProject and CcConfiguration
+        CodeCheckerProject cProj = mock(CodeCheckerProject.class);
+        CcConfigurationBase configurationBase = mock(CcConfiguration.class);
+        // Prepare a sufficent configuration. For getting the checkers, a valid
+        // codechecker location is needed.
+        @SuppressWarnings("serial")
+        Map<ConfigTypes, String> config = new HashMap<ConfigTypes, String>() {{
+                put(ConfigTypes.CHECKER_PATH, testCCRoot.toString());
+        }};
+        // Mock out the calls inside the Mocked classes.
+        when(configurationBase.get()).thenReturn(config);
+        when(cProj.getCurrentConfig()).thenReturn(configurationBase);
+        when(cProj.getLogFileLocation()).thenReturn(Paths.get("dummyPath", "inside"));
+
+        //Initialize the EnvironmentChecker with the prepared instance
+        ccec = new CodeCheckEnvironmentChecker(cProj);
+    }
+
+}

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/EnvironmentParserTest.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/EnvironmentParserTest.java
@@ -1,8 +1,8 @@
 package org.codechecker.eclipse.plugin.runtime;
 
-import com.google.common.collect.ImmutableMap;
-
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/ShellExecutorHelperTest.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/ShellExecutorHelperTest.java
@@ -1,16 +1,18 @@
 package org.codechecker.eclipse.plugin.runtime;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.exec.environment.EnvironmentUtils;
-import org.codechecker.eclipse.plugin.runtime.ShellExecutorHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.HashMap;
-
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 
 public class ShellExecutorHelperTest {
 
@@ -23,29 +25,48 @@ public class ShellExecutorHelperTest {
         defaultEnvExecutor = new ShellExecutorHelper(EnvironmentUtils.getProcEnvironment());
     }
 
+    /**
+     * Test that Change Directory command succeds on a directory with spaces. 
+     */
+    @Test
+    public void cdSucceeds() {
+        File file = null;
+        try {
+            file = Files.createTempDirectory("dir with spaces").toFile();
+            file.deleteOnExit();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        assertThat("File not exists", file.exists(), is(true));
+        Map<String, File> map = new HashMap<String, File>();
+        map.put("FILE", file);
+
+        assertThat(defaultEnvExecutor.quickAndSuccessfull("cd '${FILE}'", map), is(true));
+    }
+
     @Test
     public void emptyEnvironmentEchoes() {
-        assertThat(emptyEnvExecutor.quickReturnFirstLine("/bin/echo 5").or(""), is(equalTo("5")));
+        assertThat(emptyEnvExecutor.quickReturnFirstLine("/bin/echo 6", null).or(""), is(equalTo("6")));
     }
 
     @Test
     public void emptyEnvironmentSequence() {
-        assertThat(emptyEnvExecutor.quickReturnFirstLine("/bin/echo 4; /bin/echo 10").or(""), is
+        assertThat(emptyEnvExecutor.quickReturnFirstLine("/bin/echo 4 ; /bin/echo 10", null).or(""), is
                 (equalTo("4")));
     }
 
     @Test
     public void defaultEnvironmentEcho() { /* Should work on any sane POSIX system */
-        assertThat(defaultEnvExecutor.quickReturnFirstLine("echo 5").or(""), is(equalTo("5")));
+        assertThat(defaultEnvExecutor.quickReturnFirstLine("echo 5", null).or(""), is(equalTo("5")));
     }
 
     @Test
     public void echoSucceeds() {
-        assertThat(emptyEnvExecutor.quickAndSuccessfull("/bin/echo 4"), is(true));
+        assertThat(emptyEnvExecutor.quickAndSuccessfull("/bin/echo 3", null), is(true));
     }
 
     @Test
     public void echoooFails() {
-        assertThat(emptyEnvExecutor.quickAndSuccessfull("echooo 4;"), is(false));
+        assertThat(emptyEnvExecutor.quickAndSuccessfull("echooo 4;", null), is(false));
     }
 }

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/package-info.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/org/codechecker/eclipse/plugin/runtime/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Runtime classes Unit tests.
+ */
+package org.codechecker.eclipse.plugin.runtime;

--- a/tests/org.codechecker.eclipse.rcp.unit.tests/src/utils/package-info.java
+++ b/tests/org.codechecker.eclipse.rcp.unit.tests/src/utils/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Helper classes for unit testing.
- */
-package utils;


### PR DESCRIPTION
Depends on #145.

Fixed commands with paths passed as String to process execution

Modified every  ShellExecutorHelper method signature. Now contains an
optional substitution map for adding Paths as File for proper escaping.
Extended test with test case that test Change directory into a directory
with spaces.

Added a test case that tests getting the checkers from various path
sequences. Look in CodeCheckEnvironmentCheckerTest.java for more info.
For this purpose, a CodeChecker stub was created that return some
checkers. This Resides in the Unit test's resources folder. Current
functionality only support getting the checkers.

Resolves #147