### PR TITLE
Purged virtual environment relations

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CcConfigurationBase.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CcConfigurationBase.java
@@ -65,14 +65,6 @@ public abstract class CcConfigurationBase {
     }
 
     /**
-     * @return True if the python values are set.
-     */
-    public boolean isPythonConfigured() {
-        return !(!config.containsKey(ConfigTypes.PYTHON_PATH)
-                || (config.containsKey(ConfigTypes.PYTHON_PATH) && config.get(ConfigTypes.PYTHON_PATH).isEmpty()));
-    }
-
-    /**
      * Returns the default configuration for the plug-in.
      * @return An Unmodifiable view of the default configuration Map.
      */

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/Config.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/Config.java
@@ -5,9 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.core.runtime.IStatus;
-
 import org.codechecker.eclipse.plugin.Logger;
+import org.eclipse.core.runtime.IStatus;
 
 /**
  * Classes for handling actual configuration entries, and logging.
@@ -23,7 +22,6 @@ public class Config {
     public enum ConfigTypes {
         // Common configuration values
         CHECKER_PATH("codechecker_path"),
-        PYTHON_PATH(""),
         COMPILERS("gcc:g++:clang:clang++"),
         ANAL_THREADS("4"),
         CHECKER_LIST("enabled_checkers"),

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/EnvironmentVariables.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/EnvironmentVariables.java
@@ -1,8 +1,5 @@
 package org.codechecker.eclipse.plugin.config;
 
-import java.util.EnumSet;
-import java.util.Set;
-
 import org.eclipse.cdt.core.envvar.IEnvironmentVariable;
 
 /**
@@ -14,14 +11,7 @@ public enum EnvironmentVariables {
     CC_LOGGER_GCC_LIKE("clang", IEnvironmentVariable.ENVVAR_REPLACE),
     LD_PRELOAD("ldlogger.so", IEnvironmentVariable.ENVVAR_REPLACE),
     CC_LOGGER_FILE("logfile", IEnvironmentVariable.ENVVAR_REPLACE),
-    CC_LOGGER_BIN("/bin/ldlogger", IEnvironmentVariable.ENVVAR_REPLACE),
-    //python variables comes after this;
-    PATH("/bin:", IEnvironmentVariable.ENVVAR_PREPEND),
-    VIRTUAL_ENV("pythonEnv", IEnvironmentVariable.ENVVAR_REPLACE);
-
-    public static Set<EnvironmentVariables> BASE_TYPE = EnumSet.range(LD_LIBRARY_PATH, CC_LOGGER_BIN);
-    public static Set<EnvironmentVariables> PYTHON_TYPE = EnumSet.range(PATH, VIRTUAL_ENV);
-    public static Set<EnvironmentVariables> ALL = EnumSet.range(LD_LIBRARY_PATH, VIRTUAL_ENV);
+    CC_LOGGER_BIN("/bin/ldlogger", IEnvironmentVariable.ENVVAR_REPLACE);
 
     private String defaultValue;
     private int method;

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/project/CodeCheckerProject.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/project/CodeCheckerProject.java
@@ -90,7 +90,7 @@ public class CodeCheckerProject implements ConfigurationChangedListener {
      */
     private void setEnvironment() {
         //Initialize to defaults.
-        for (EnvironmentVariables ev :EnvironmentVariables.BASE_TYPE) {
+        for (EnvironmentVariables ev : EnvironmentVariables.values()) {
             environmentVariables.put(ev, ev.getDefaultValue());
         }
         String checkerDir = current.get(ConfigTypes.CHECKER_PATH);
@@ -107,14 +107,6 @@ public class CodeCheckerProject implements ConfigurationChangedListener {
                 Paths.get(codeCheckerWorkspace.toString(),
                         COMPILATION_COMMANDS).toString());
 
-        if (current.isPythonConfigured()) {
-            for (EnvironmentVariables ev :EnvironmentVariables.PYTHON_TYPE) {
-                environmentVariables.put(ev, ev.getDefaultValue());
-            }
-            environmentVariables.put(EnvironmentVariables.PATH,
-                    current.get(ConfigTypes.PYTHON_PATH) + EnvironmentVariables.PATH.getDefaultValue());
-            environmentVariables.put(EnvironmentVariables.VIRTUAL_ENV, current.get(ConfigTypes.PYTHON_PATH));
-        }
         modifyProjectEnvironmentVariables();
     }
 

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,6 @@ Run `mvn -f mavendeps/pom.xml p2:site && mvn clean verify` in the root of the pr
 Make sure that before staring Eclipse:
 
 * CodeChecker/bin directory is included in PATH (e.g.: `export PATH="/home/<username>/CodeChecker/bin/:$PATH"`)
-* Python virtualenv with CodeChecker dependencies is sourced (e.g.: `source /home/<username>/venv/bin/activate`)
 
 __Currently the plugin is only usable with a CDT project.__
 

--- a/tests/org.codechecker.eclipse.rcp.it.tests/src/org/codechecker/eclipse/plugin/IndicatorTest.java
+++ b/tests/org.codechecker.eclipse.rcp.it.tests/src/org/codechecker/eclipse/plugin/IndicatorTest.java
@@ -8,7 +8,6 @@ import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCLabel;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
-import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.hamcrest.core.IsNull;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -74,13 +73,7 @@ public class IndicatorTest {
     @Test
     public void testCodeCheckerFound() {
         Path ccDir = Utils.prepareCodeChecker();
-  
-        SWTBotText text = bot.textWithLabel("CodeChecker package root directory");
-        text.setText(ccDir.toString());
-        text.setFocus();
-        bot.textWithLabel("Python virtualenv root directory (optional)").setFocus();
-        
-        bot.sleep(SHORT_WAIT_TIME);
+        GuiUtils.setCCBinDir(ccDir, bot);
 
         SWTBotCLabel label = null;
         try {

--- a/tests/org.codechecker.eclipse.rcp.it.tests/src/org/codechecker/eclipse/plugin/utils/GuiUtils.java
+++ b/tests/org.codechecker.eclipse.rcp.it.tests/src/org/codechecker/eclipse/plugin/utils/GuiUtils.java
@@ -44,7 +44,7 @@ public final class GuiUtils {
     public static final String ENVIR_LOGGER_BIN = "CC_LOGGER_BIN";
     public static final String ENVIR_LOGGER_FILE = "CC_LOGGER_FILE";
     public static final String LDOGGER = "ldlogger";
-    public static final String PY_DIR_WIDGET = "Python virtualenv root directory (optional)";
+    public static final String THREAD_WIDGET = "Number of analysis threads";
     public static final String GLOBAL_RADIO = "Use global configuration";
     public static final String PROJECT_RADIO = "Use project configuration";
     
@@ -110,10 +110,10 @@ public final class GuiUtils {
     public static void setCCBinDir(Path ccDir, SWTWorkbenchBot bot) {
         SWTBotText text = bot.textWithLabel(GuiUtils.CC_DIR_WIDGET);
         text.setText(ccDir.toString());
-        text.setFocus();
-        bot.textWithLabel(GuiUtils.PY_DIR_WIDGET).setFocus();
+        // text.setFocus();
+        // bot.textWithLabel(THREAD_WIDGET).setFocus();
 
-        bot.sleep(SHORT_WAIT_TIME);
+        // bot.sleep(SHORT_WAIT_TIME);
     }
 
     /**


### PR DESCRIPTION
Codechecker now supports a standalone package target, resulting that a
python environment is unnecessary.

Removed from both the gui and from the internal parts.

Also there is a small change in the package binary directory widget. The
default listener was changed to a modify listener for robustness, and
for an easier guitesting.