### PR TITLE
Clear checker report view when needed

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/init/ProjectExplorerSelectionListener.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/init/ProjectExplorerSelectionListener.java
@@ -1,16 +1,13 @@
 package org.codechecker.eclipse.plugin.init;
 
+import org.codechecker.eclipse.plugin.config.CodeCheckerContext;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
-
-import org.codechecker.eclipse.plugin.CodeCheckerNature;
-import org.codechecker.eclipse.plugin.config.CodeCheckerContext;
 
 public class ProjectExplorerSelectionListener implements ISelectionListener {
 
@@ -22,13 +19,9 @@ public class ProjectExplorerSelectionListener implements ISelectionListener {
                 IResource resource = (IResource) ((IAdaptable) element).getAdapter(IResource.class);
                 if (resource != null) {
                     final IProject project = resource.getProject();
-                    try {
-                        if (project != null && project.hasNature(CodeCheckerNature.NATURE_ID))
-                            CodeCheckerContext.getInstance().refreshChangeProject(project);
-                    } catch (CoreException e) {
-                        // TODO Auto-generated catch block
-                        e.printStackTrace();
-                    }
+                    if (project != null)
+                        CodeCheckerContext.getInstance().refreshChangeProject(project);
+
                 }
             }
         }


### PR DESCRIPTION
When changing from a project which isn't CodeChecker enabled the report
views will show no reports.

Also when changing between files.