### PR TITLE
Startup fixes

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/init/StartupJob.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/init/StartupJob.java
@@ -105,7 +105,8 @@ public class StartupJob extends Job {
      * @param project The project that got opened.
      */
     private void projectOpened(IProject project) {
-        if (project == null)
+        // We should return if the project is inaccessible.
+        if (project == null || !project.isAccessible())
             return;
         try {
             // If CodecheCker nature is not set or the project is non-CDT we can't parse anything.

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
@@ -77,8 +77,7 @@ public class AnalyzeJob extends Job {
             int numberOfAnalyzers = 2;
             config.getCodeChecker().analyze(logFile, true, monitor, taskCount.get() * numberOfAnalyzers, config);
         } catch (NullPointerException e) {
-            // TODO: Notify the user somehow that the analyze couldn't be completed, because
-            // there is no CodeChecker configured.
+            Logger.log(IStatus.ERROR, "Could not complete the analysis");
         }
 
         deleteLogFile();


### PR DESCRIPTION
There was nullpointer exceptions accessing projects not previously
opened, and CodeChecker was not initialized in configuration when a
previously closed project was opened.