### PR TITLE
Cancelable CodeChecker analyze

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/codechecker/CodeChecker.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/codechecker/CodeChecker.java
@@ -120,4 +120,9 @@ public class CodeChecker implements ICodeChecker {
                 + config.get(ConfigTypes.ANAL_THREADS) + " -n javarunner" + " -o " + RESULTS_SUB + OPTION_SEPARATOR
                 + LOGFILE_SUB + OPTION_SEPARATOR + config.get(ConfigTypes.ANAL_OPTIONS);
     }
+
+    @Override
+    public void cancelAnalyze() {
+        she.cancel();
+    }
 }

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/codechecker/ICodeChecker.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/codechecker/ICodeChecker.java
@@ -70,4 +70,6 @@ public interface ICodeChecker {
      */
     public String analyze(Path logFile, boolean logToConsole, IProgressMonitor monitor, int taskCount,
             CcConfigurationBase config);
+
+    public void cancelAnalyze();
 }

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
@@ -84,6 +84,11 @@ public class AnalyzeJob extends Job {
         return Status.OK_STATUS;
     }
     
+    @Override
+    protected void canceling() {
+        config.getCodeChecker().cancelAnalyze();
+    }
+
     /**
      * Creates a copy of the log file created by ld logger, to avoid concurrency
      * issues.
@@ -107,4 +112,5 @@ public class AnalyzeJob extends Job {
             Logger.log(IStatus.ERROR, "Couldn't delete the temporary log file!");
         }
     }
+
 }


### PR DESCRIPTION
The analysis progress monitor had a cancel button, but there was no
wiring behind it.
Now a an analyze job being run can be cancelled in the progress tab.
This will also kill the underlying process.