### PR TITLE
Fixes for linked resources

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CodeCheckerContext.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/config/CodeCheckerContext.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.IViewReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.FileEditorInput;
 /**
  * The Class CodeCheckerContext.
  */
@@ -258,7 +259,8 @@ public class CodeCheckerContext {
             CodeCheckerProject ccProj = projects.get(project);
             String filename = "";
             if (ccProj != null)
-                filename = ccProj.getAsProjectRelativePath(file.getProjectRelativePath().toString());
+                filename = ((FileEditorInput) partRef.getEditorInput()).getFile().getLocation().toFile().toPath()
+                        .toString();
 
             IWorkbenchWindow activeWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
             if (activeWindow == null) {
@@ -343,12 +345,13 @@ public class CodeCheckerContext {
             return;
         }
 
-        Logger.log(IStatus.INFO, "Started Filtering Reports for project: "+project.getName());
+        Logger.log(IStatus.INFO, "Started Filtering Reports for project: " + project.getName() + " " + currentFileName);
 
         ReportParser parser = new ReportParser(reports.get(project), currentFileName);
         // add listeners to it.
         parser.addListener(new ReportListViewListener(target));
         Display.getDefault().asyncExec(parser);
-        Logger.log(IStatus.INFO, "Finished Filtering Reports for project: "+project.getName());
+        Logger.log(IStatus.INFO,
+                "Finished Filtering Reports for project: " + project.getName() + " " + currentFileName);
     }
 }

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/report/job/AnalyzeJob.java
@@ -129,6 +129,7 @@ public class AnalyzeJob extends Job {
         sb.append(SKIP_ENABLE).append("*.hh").append(System.lineSeparator());
         sb.append(SKIP_ENABLE).append("*.hxx").append(System.lineSeparator());
         sb.append(SKIP_DISABLE).append(project.getLocationPrefix()).append("*").append(System.lineSeparator());
+        sb.append(SKIP_DISABLE).append("/*");
         try {
             skipFile = Files.createTempFile("skipFile", null);
             Files.write(skipFile, sb.toString().getBytes(), StandardOpenOption.CREATE);


### PR DESCRIPTION
Sources that reside in an eclipse project with a linked state, (similar to symlinks but not the same) wouldn't get reports displayed.

Patch by Vodorok.