### PR TITLE
Checker documentation can be accessable from report list

### DIFF
--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/command/OpenDocsAction.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/command/OpenDocsAction.java
@@ -1,0 +1,48 @@
+package org.codechecker.eclipse.plugin.command;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.codechecker.eclipse.plugin.Logger;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jface.action.Action;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Action for opening a browser with an arbitrary url.
+ */
+public class OpenDocsAction extends Action {
+
+    private final String url;
+
+    /**
+     * Constructor where you must specify an url.
+     * 
+     * @param url
+     *            The url to be used. Must not be null
+     */
+    public OpenDocsAction(@NonNull String url) {
+        super("View Documentation");
+        this.url = url;
+    }
+
+    @Override
+    public void run() {
+        try {
+            PlatformUI.getWorkbench().getBrowserSupport().createBrowser("CodeChecker")
+                    .openURL(new URL(url));
+        } catch (PartInitException | MalformedURLException e) {
+            Logger.log(IStatus.ERROR, "Couldn't go to link.");
+        }
+    }
+
+    /**
+     * Holder class for the actual links.
+     */
+    public final class DocTypes {
+        public static final String SA = "https://clang.llvm.org/docs/analyzer/checkers.html";
+        public static final String TIDY = "https://clang.llvm.org/extra/clang-tidy/checks/list.html";
+    }
+}

--- a/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/views/report/list/ReportListView.java
+++ b/bundles/org.codechecker.eclipse.plugin/src/org/codechecker/eclipse/plugin/views/report/list/ReportListView.java
@@ -10,10 +10,13 @@ import java.util.List;
 
 import org.codechecker.eclipse.plugin.Activator;
 import org.codechecker.eclipse.plugin.Logger;
+import org.codechecker.eclipse.plugin.command.OpenDocsAction;
+import org.codechecker.eclipse.plugin.command.OpenDocsAction.DocTypes;
 import org.codechecker.eclipse.plugin.config.CodeCheckerContext;
 import org.codechecker.eclipse.plugin.config.filter.Filter;
 import org.codechecker.eclipse.plugin.config.filter.FilterConfiguration;
 import org.codechecker.eclipse.plugin.report.BugPathItem;
+import org.codechecker.eclipse.plugin.report.ReportInfo;
 import org.codechecker.eclipse.plugin.report.SearchList;
 import org.codechecker.eclipse.plugin.report.job.AnalyzeJob;
 import org.codechecker.eclipse.plugin.report.job.JobDoneChangeListener;
@@ -43,7 +46,9 @@ import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TreePath;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseEvent;
@@ -223,7 +228,26 @@ public class ReportListView extends ViewPart {
     }
 
     private void fillContextMenu(IMenuManager manager) {
-        //manager.add(new RerunSelectedAction(this));
+        IStructuredSelection sel = viewer.getStructuredSelection();
+        Object selection = sel.getFirstElement();
+        TreePath tp = ((ITreeSelection) sel).getPaths()[0];
+        for (int i = 0; i < tp.getSegmentCount(); i++) {
+            Object segment = tp.getSegment(i);
+            // We are simply relying on string contain,
+            // * Can't go from BugPathItem to ReportInfo
+            // * ReportInfo on the gui wont show the checker
+            if (selection instanceof ReportInfo || selection instanceof BugPathItem)
+                break;
+            if (segment instanceof String) {
+                if (((String) segment).contains(".")) {
+                    manager.add(new OpenDocsAction(DocTypes.SA));
+                    break;
+                } else if (((String) segment).contains("-")) {
+                    manager.add(new OpenDocsAction(DocTypes.TIDY));
+                    break;
+                }
+            }
+        }
         manager.add(new NewInstanceAction(new ReportListViewCustom()));
         manager.add(new Separator());
         // Other plug-ins can contribute there actions here


### PR DESCRIPTION
In a report category tree item context menu, there is a View Documentation
menu item. Clicking on this, the default browser opens with the Clang
static analyzer, or Clang Tidy documentation grouping page.